### PR TITLE
canceling replay audio when switchign q, better wording for the ai feedback

### DIFF
--- a/changes/CHANGES_2026-05-06_05-09.md
+++ b/changes/CHANGES_2026-05-06_05-09.md
@@ -23,6 +23,9 @@ Test flow updates: five-photo ordering and 40s expression timing/slicing
 7. Updated summary pending-phase text for `preparing_audio` to user-friendly “Processing audio” / `מעבד שמע` to better reflect backend behavior.
 8. Updated footer build label in `frontend_demo/app.js` from `version 2` to `version 2.1`.
 9. Updated test flow audio behavior so when `try_again.mp3` is played, the question audio is replayed automatically as soon as the try-again clip ends (with pause/mute/session safety guards).
+10. Hardened try-again replay handling on question transitions: try-again audio is now stopped/cleared on `loadQuestion`, and replay-after-try-again only triggers if the user is still on the same question that started the clip; also clarified queue phase copy to “Waiting in AI feedback queue” / `ממתין בתור למשוב AI`.
+11. Updated the English queued-phase copy to user-friendly wording: “Feedback generation will start shortly”.
+12. Updated the Hebrew queued-phase copy to match the same user-friendly meaning: `יצירת המשוב תתחיל בקרוב`.
 
 ## numbered notes
 1. Existing behavior where users may submit evaluation before timeout is unchanged; only the auto-evaluation cutoff/lock moved to 40 seconds.

--- a/frontend_demo/test.js
+++ b/frontend_demo/test.js
@@ -1392,8 +1392,10 @@ const handleReadingValidationRetry = function () {
         tryAgainAudioRef.current = new Audio("resources/questions_audio/try_again.mp3");
       }
       const a = tryAgainAudioRef.current;
+      var replayQuestionIdx = getCurrentQuestionIndex();
       a.onended = function () {
         if (questionAudioMuted || isPausedRef.current || sessionCompletedRef.current) return;
+        if (getCurrentQuestionIndex() !== replayQuestionIdx) return;
         if (questionType !== "C" && questionType !== "E") return;
         replayQuestionAudio();
       };
@@ -2284,6 +2286,13 @@ const handleReadingValidationRetry = function () {
         questionAudio.currentTime = 0;
       } catch (e) {}
       setIsAudioPlaying(false);
+    }
+    if (tryAgainAudioRef.current) {
+      try {
+        tryAgainAudioRef.current.pause();
+        tryAgainAudioRef.current.currentTime = 0;
+      } catch (e) {}
+      tryAgainAudioRef.current.onended = null;
     }
     // Clear previous question visuals immediately to avoid stale-image flash while switching.
     setCurrentQuestionImagesLoaded(false);
@@ -3652,7 +3661,7 @@ function renderExpectedAnswerNote() {
       : "pending";
     function expressionPhaseLabel(phaseKey) {
       if (lang === "en") {
-        if (phaseKey === "queued") return "Queued";
+        if (phaseKey === "queued") return "Feedback generation will start shortly";
         if (phaseKey === "processing_started") return "Started";
         if (phaseKey === "preparing_audio") return "Processing audio";
         if (phaseKey === "scoring_questions") return "Scoring questions";
@@ -3661,7 +3670,7 @@ function renderExpectedAnswerNote() {
         if (phaseKey === "failed") return "Failed";
         return "Pending";
       }
-      if (phaseKey === "queued") return "ממתין בתור";
+      if (phaseKey === "queued") return "יצירת המשוב תתחיל בקרוב";
       if (phaseKey === "processing_started") return "התחיל עיבוד";
       if (phaseKey === "preparing_audio") return "מעבד שמע";
       if (phaseKey === "scoring_questions") return "מחשב ציונים";


### PR DESCRIPTION
1. Hardened try-again replay handling on question transitions: try-again audio is now stopped/cleared on `loadQuestion`, and replay-after-try-again only triggers if the user is still on the same question that started the clip; also clarified queue phase copy to “Waiting in AI feedback queue” / `ממתין בתור למשוב AI`.
2. Updated the English queued-phase copy to user-friendly wording: “Feedback generation will start shortly”.
3. Updated the Hebrew queued-phase copy to match the same user-friendly meaning: `יצירת המשוב תתחיל בקרוב`.