### PR TITLE
display ai feedback on the screen in addition to word and make it persistent

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -40,7 +40,7 @@ database_name = os.environ.get("DATABASE_NAME")
 
 # Initialize MongoDB storage manager
 storage = SeeSayMongoStorage(mongodb_url, database_name)
-GEMINI_DAILY_LIMIT = int(os.environ.get("GEMINI_DAILY_LIMIT", "100"))
+GEMINI_DAILY_LIMIT = int(os.environ.get("GEMINI_DAILY_LIMIT", "150"))
 GEMINI_MAX_SEGMENT_SECONDS = int(os.environ.get("GEMINI_MAX_SEGMENT_SECONDS", "40"))
 GEMINI_IMPRESSION_DAILY_LIMIT = int(os.environ.get("GEMINI_IMPRESSION_DAILY_LIMIT", "200"))
 GEMINI_IMPRESSION_MAX_OUTPUT_TOKENS = int(os.environ.get("GEMINI_IMPRESSION_MAX_OUTPUT_TOKENS", "2800"))

--- a/changes/CHANGES_2026-05-07_05-09.md
+++ b/changes/CHANGES_2026-05-07_05-09.md
@@ -6,12 +6,12 @@ Brief running log for changes made from 7 May to 9 May 2026.
 
 ## PR title
 
-Changelog period switch, completion summary, PLS narrative, expression feedback UX notes, and app footer version 3
+Changelog period switch, completion summary, PLS narrative, expression feedback UX notes, app footer version 3, and inline expression AI report on completion
 
 ## Summary (2-3 bullets)
 - Switched the active running changelog target to the new 7-9 May period file and froze the prior window in a dedicated 6-7 May archive.
 - Reworked the completion screen (visual summary, cakes, mobile containment, Word AI export with parent-vs-AI comparison) without changing per-question 0/1/2 scoring logic.
-- Delivered PLS-style narrative reporting and Word slimming (semantics-driven prompts, semantics vs category PLS clarity), recorded that optional JS traffic-sheet / evaluate-emoji sync fixes were not kept, added randomized expression "try again" voice feedback source selection, moved the start/login form into welcome step 2 while preserving the same permission/create-user flow before entering test, refined this welcome-login flow with better legal-link contrast/no nav arrows/one-time resume prompt/old-login removal/updated welcome copy, implemented explicit question end-timestamp event support so slicing windows can close on actual question transitions, switched test image resolution to prefer `.webp` with `.png` fallback for most questions while mask `A` questions keep `A.png` masks and now load option photos **PNG-first** with WebP fallback for better mask alignment, and bumped the global footer label to **version 3**.
+- Delivered PLS-style narrative reporting and Word slimming (semantics-driven prompts, semantics vs category PLS clarity), recorded that optional JS traffic-sheet / evaluate-emoji sync fixes were not kept, added randomized expression "try again" voice feedback source selection, moved the start/login form into welcome step 2 while preserving the same permission/create-user flow before entering test, refined this welcome-login flow with better legal-link contrast/no nav arrows/one-time resume prompt/old-login removal/updated welcome copy, implemented explicit question end-timestamp event support so slicing windows can close on actual question transitions, switched test image resolution to prefer `.webp` with `.png` fallback for most questions while mask `A` questions keep `A.png` masks and now load option photos **PNG-first** with WebP fallback for better mask alignment, bumped the global footer label to **version 3**, show the expression AI parent-vs-AI table **inline** on the completion summary (Word download remains optional for sharing) with the inline **Match** column removed so **Reason** gets wider, persist completion AI feedback/test-id in local storage so refresh keeps the summary feedback visible, raised the expression AI daily quota default from **100** to **150**, and updated the footer label again to **version 3.1**.
 
 ## numbered main changes
 1. Created `changes/CHANGES_2026-05-07_05-09.md` as the active running changelog period file.
@@ -67,6 +67,11 @@ Changelog period switch, completion summary, PLS narrative, expression feedback 
 51. Updated test image resolution order to prefer `.webp` first for question photos (including preloading paths) with `.png` fallback in UI image elements, while enforcing mask click-region assets (`A.png`) as PNG-only with no WebP fallback.
 52. For mask answer type `A`, comprehension option images now resolve **`.png` first** with `.webp` on `onError`, comprehension `<img>` tags set `data-fallback-png-first`, and `ImageLoader` prefetches/`areImagesLoaded`/`prioritizeQuestion` use PNG URLs for those rows (including correct `n|m` image counts) so loading gates match displayed assets.
 53. Updated the footer `app-version-label` copy in `frontend_demo/app.js` from `version 2.2` to `version 3`.
+54. On session completion, render the expression AI feedback table (parent answer/score, AI score, match, reason, listen + match count) **inside** the immediate summary card below the donut cards when expression AI is resolved, sharing row logic with the Word export; added scrollable table styling in `styles.css` and clarified the Word button copy as optional download for devices that do not open `.doc` well.
+55. Updated the inline completion-screen expression AI table to remove the per-row **Match** column (while keeping the top-level `x / y` match count), and expanded the **Reason** header width to use that freed space for better readability on phones.
+56. Persisted `lastCompletedTestId` and `expressionAiResult` via `usePersistentState` in `test.js` so refreshing on the completion screen retains the saved AI feedback/summary state without storing large audio blobs in local storage.
+57. Increased backend expression AI daily quota default by changing `GEMINI_DAILY_LIMIT` fallback in `backend/server.py` from `100` to `150` (still overridable by env var).
+58. Updated the app footer label in `frontend_demo/app.js` from `version 3` to `version 3.1`.
 
 ## numbered notes
 1. If pre-timer evaluate-emoji opens flake again, the reverted JS guard + gate-key sync can be reintroduced narrowly without restoring full-screen dim or blocking overlay capture.

--- a/frontend_demo/app.js
+++ b/frontend_demo/app.js
@@ -244,7 +244,7 @@ function App() {
     React.createElement(
       "div",
       { className: "app-version-label", "aria-hidden": "true" },
-      "version 3"
+      "version 3.1"
     ),
     // Landscape orientation overlay — shown only in test mode + portrait
     React.createElement(

--- a/frontend_demo/css/styles.css
+++ b/frontend_demo/css/styles.css
@@ -1962,6 +1962,49 @@ button {
   font-size: 14px;
 }
 
+/* Inline expression AI report (same data as Word export) — below visual summary on completion */
+.session-expression-ai-report {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  margin-top: 14px;
+  padding: 12px 10px 14px;
+  background: #fbfcff;
+  border: 1px solid #dbe5ef;
+  border-radius: 14px;
+  text-align: start;
+  direction: inherit;
+}
+
+.session-expression-ai-report__title {
+  margin: 0 0 8px;
+  font-size: 16px;
+  font-weight: 800;
+  color: #20364a;
+  text-align: center;
+}
+
+.session-expression-ai-report__matchline {
+  margin: 0 0 10px;
+  font-size: 14px;
+  color: #3d5266;
+  text-align: center;
+}
+
+.session-expression-ai-report__scroll {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.session-expression-ai-report__table {
+  width: 100%;
+  min-width: 520px;
+  border-collapse: collapse;
+  font-family: "Rubik", var(--font-family), sans-serif;
+}
+
 .session-visual-summary {
   width: 100%;
   margin: 0;

--- a/frontend_demo/test.js
+++ b/frontend_demo/test.js
@@ -53,8 +53,8 @@ function Test({ allQuestions, lang, t, onHome, onReset, setLang, onTestPhase }) 
 
   // Transcription state
   const [transcription, setTranscription] = React.useState(null);
-  const [lastCompletedTestId, setLastCompletedTestId] = React.useState(null);
-  const [expressionAiResult, setExpressionAiResult] = React.useState(null);
+  const [lastCompletedTestId, setLastCompletedTestId] = usePersistentState("lastCompletedTestId", null);
+  const [expressionAiResult, setExpressionAiResult] = usePersistentState("expressionAiResult", null);
   const [expressionAiLoading, setExpressionAiLoading] = React.useState(false);
   /** Which PLS frame is selected in the narrative report wheel (integrative | semantics | structure | phonology). */
   const [plsReportCategory, setPlsReportCategory] = React.useState("semantics");
@@ -4076,14 +4076,7 @@ function renderExpectedAnswerNote() {
       
       console.log("📥 Downloaded session data file with timestamps, results, and transcription");
     };
-    const buildExpressionAiReportPayload = function () {
-      if (!expressionAiResult) return;
-      var rows = Array.isArray(expressionAiResult.per_question) ? expressionAiResult.per_question : [];
-      return {
-        testId: lastCompletedTestId || "unknown",
-        rows: rows
-      };
-    };
+
     const parentStatusForReport = function (parentResult) {
       if (parentResult === "correct") return lang === "en" ? "Success" : "הצליח";
       if (parentResult === "partly") return lang === "en" ? "Partial" : "חלקי";
@@ -4096,37 +4089,163 @@ function renderExpectedAnswerNote() {
       if (parentResult === "wrong") return 0;
       return null;
     };
-    const downloadExpressionAiReportDoc = function () {
-      var payload = buildExpressionAiReportPayload();
-      if (!payload) return;
+
+    const getExpressionAiReportRowModels = function () {
+      if (!expressionAiResult) return null;
+      var rawRows = Array.isArray(expressionAiResult.per_question) ? expressionAiResult.per_question : [];
       var gradeMatchedCount = 0;
       var gradeComparedCount = 0;
-      var rowsHtml = payload.rows.length
-        ? payload.rows.map(function (r) {
-            var qn = String((r && r.question_number) != null ? r.question_number : "");
-            var parentResult = parentExprByQ[qn];
-            var parentStatus = parentStatusForReport(parentResult);
-            var parentScore = parentScoreForReport(parentResult);
-            var aiScoreNum = (r && (r.ai_score === 0 || r.ai_score === 1 || r.ai_score === 2)) ? Number(r.ai_score) : null;
-            var isMatch = parentScore != null && aiScoreNum != null ? (parentScore === aiScoreNum) : null;
-            if (isMatch !== null) {
-              gradeComparedCount += 1;
-              if (isMatch) gradeMatchedCount += 1;
-            }
+      var rowModels = rawRows.map(function (r) {
+        var qn = String((r && r.question_number) != null ? r.question_number : "");
+        var parentResult = parentExprByQ[qn];
+        var parentStatus = parentStatusForReport(parentResult);
+        var parentScore = parentScoreForReport(parentResult);
+        var aiScoreNum = (r && (r.ai_score === 0 || r.ai_score === 1 || r.ai_score === 2)) ? Number(r.ai_score) : null;
+        var isMatch = parentScore != null && aiScoreNum != null ? (parentScore === aiScoreNum) : null;
+        if (isMatch !== null) {
+          gradeComparedCount += 1;
+          if (isMatch) gradeMatchedCount += 1;
+        }
+        var matchLabel =
+          isMatch === null
+            ? "—"
+            : isMatch
+              ? (lang === "en" ? "Match" : "תואם")
+              : (lang === "en" ? "Different" : "שונה");
+        return {
+          qn: qn || "—",
+          parentStatus: parentStatus,
+          parentScoreStr: parentScore == null ? "—" : String(parentScore),
+          aiScoreStr: String((r && r.ai_score) != null ? r.ai_score : "—"),
+          matchLabel: matchLabel,
+          reason: String((r && r.ai_reason_short) || "—"),
+          listen: String((r && r.ai_speaker_observation) || "—")
+        };
+      });
+      return {
+        rowModels: rowModels,
+        gradeMatchedCount: gradeMatchedCount,
+        gradeComparedCount: gradeComparedCount
+      };
+    };
+
+    const renderExpressionAiReportInline = function () {
+      if (!expressionAiResolved || !hasExpressionQuestions || !expressionAiResult) return null;
+      var pack = getExpressionAiReportRowModels();
+      if (!pack) return null;
+      var rowModels = pack.rowModels;
+      var thStyle = {
+        border: "1px solid #cfd8e6",
+        padding: "8px 6px",
+        fontSize: "12px",
+        background: "#eef2f8",
+        color: "#1f3d53",
+        fontWeight: 700
+      };
+      var tdStyle = {
+        border: "1px solid #e2e8f0",
+        padding: "8px 6px",
+        fontSize: "12px",
+        color: "#2c3e50",
+        textAlign: "start",
+        verticalAlign: "top",
+        wordBreak: "break-word"
+      };
+      function th(label, extraStyle) {
+        return React.createElement("th", { style: Object.assign({}, thStyle, extraStyle || {}), scope: "col" }, label);
+      }
+      function cell(text) {
+        return React.createElement("td", { style: tdStyle }, text);
+      }
+      var thead = React.createElement(
+        "thead",
+        null,
+        React.createElement(
+          "tr",
+          null,
+          th("Q#"),
+          th(lang === "en" ? "Parent answer" : "תשובת הורה"),
+          th(lang === "en" ? "Parent score" : "ציון הורה"),
+          th("AI score"),
+          th(lang === "en" ? "Reason" : "סיבה", { minWidth: "220px", width: "40%" }),
+          th(lang === "en" ? "Listen" : "האזנה")
+        )
+      );
+      var tbody;
+      if (rowModels.length === 0) {
+        tbody = React.createElement(
+          "tbody",
+          null,
+          React.createElement(
+            "tr",
+            null,
+            React.createElement(
+              "td",
+              { colSpan: 6, style: Object.assign({}, tdStyle, { textAlign: "center" }) },
+              lang === "en" ? "No per-question AI rows." : "אין שורות AI לפי שאלה."
+            )
+          )
+        );
+      } else {
+        tbody = React.createElement(
+          "tbody",
+          null,
+          rowModels.map(function (m, idx) {
+            return React.createElement(
+              "tr",
+              { key: "expr-ai-row-" + idx },
+              cell(m.qn),
+              cell(m.parentStatus),
+              cell(m.parentScoreStr),
+              cell(m.aiScoreStr),
+              cell(m.reason),
+              cell(m.listen)
+            );
+          })
+        );
+      }
+      return React.createElement(
+        "div",
+        { className: "session-expression-ai-report" },
+        React.createElement(
+          "h3",
+          { className: "session-expression-ai-report__title" },
+          lang === "en" ? "Expression AI feedback report" : "דוח משוב הבעה (AI)"
+        ),
+        React.createElement(
+          "p",
+          { className: "session-expression-ai-report__matchline" },
+          React.createElement("strong", null, lang === "en" ? "Parent vs AI match: " : "התאמה הורה מול AI: "),
+          String(pack.gradeMatchedCount) + " / " + String(pack.gradeComparedCount)
+        ),
+        React.createElement(
+          "div",
+          { className: "session-expression-ai-report__scroll" },
+          React.createElement("table", { className: "session-expression-ai-report__table" }, thead, tbody)
+        )
+      );
+    };
+
+    const downloadExpressionAiReportDoc = function () {
+      var pack = getExpressionAiReportRowModels();
+      if (!pack) return;
+      var testId = lastCompletedTestId || "unknown";
+      var rowsHtml = pack.rowModels.length
+        ? pack.rowModels.map(function (m) {
             return "<tr>" +
-              "<td style='border:1px solid #bbb;padding:6px;'>"+ (qn || "—") +"</td>" +
-              "<td style='border:1px solid #bbb;padding:6px;'>"+ parentStatus +"</td>" +
-              "<td style='border:1px solid #bbb;padding:6px;'>"+ (parentScore == null ? "—" : String(parentScore)) +"</td>" +
-              "<td style='border:1px solid #bbb;padding:6px;'>"+ String((r && r.ai_score) != null ? r.ai_score : "—") +"</td>" +
-              "<td style='border:1px solid #bbb;padding:6px;'>"+ (isMatch === null ? "—" : (isMatch ? (lang === "en" ? "Match" : "תואם") : (lang === "en" ? "Different" : "שונה"))) +"</td>" +
-              "<td style='border:1px solid #bbb;padding:6px;'>"+ String((r && r.ai_reason_short) || "—") +"</td>" +
-              "<td style='border:1px solid #bbb;padding:6px;'>"+ String((r && r.ai_speaker_observation) || "—") +"</td>" +
+              "<td style='border:1px solid #bbb;padding:6px;'>"+ m.qn +"</td>" +
+              "<td style='border:1px solid #bbb;padding:6px;'>"+ m.parentStatus +"</td>" +
+              "<td style='border:1px solid #bbb;padding:6px;'>"+ m.parentScoreStr +"</td>" +
+              "<td style='border:1px solid #bbb;padding:6px;'>"+ m.aiScoreStr +"</td>" +
+              "<td style='border:1px solid #bbb;padding:6px;'>"+ m.matchLabel +"</td>" +
+              "<td style='border:1px solid #bbb;padding:6px;'>"+ m.reason +"</td>" +
+              "<td style='border:1px solid #bbb;padding:6px;'>"+ m.listen +"</td>" +
               "</tr>";
           }).join("")
         : "<tr><td colspan='7' style='border:1px solid #bbb;padding:6px;'>No per-question AI rows.</td></tr>";
       var html = "<html><head><meta charset='utf-8'><title>Expression AI Report</title></head><body style='font-family:Arial,sans-serif;padding:16px;'>" +
         "<h2>Expression AI Feedback Report</h2>" +
-        "<p><strong>" + (lang === "en" ? "Parent vs AI match" : "התאמה הורה מול AI") + ":</strong> " + gradeMatchedCount + " / " + gradeComparedCount + "</p>" +
+        "<p><strong>" + (lang === "en" ? "Parent vs AI match" : "התאמה הורה מול AI") + ":</strong> " + pack.gradeMatchedCount + " / " + pack.gradeComparedCount + "</p>" +
         "<h3>Per-question rows</h3>" +
         "<table style='border-collapse:collapse;width:100%;font-size:13px;'><thead><tr>" +
         "<th style='border:1px solid #bbb;padding:6px;'>Q#</th>" +
@@ -4142,7 +4261,7 @@ function renderExpectedAnswerNote() {
       var url = URL.createObjectURL(blob);
       var a = document.createElement("a");
       a.href = url;
-      a.download = "expression_ai_feedback_" + payload.testId + ".doc";
+      a.download = "expression_ai_feedback_" + testId + ".doc";
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
@@ -4469,6 +4588,7 @@ function renderExpectedAnswerNote() {
           stats: expressionCakeStats
         })
       ),
+      renderExpressionAiReportInline(),
       expressionAiResolved
         ? React.createElement("div", { className: "session-immediate-summary__balance" }, strongerLabel)
         : null
@@ -4565,8 +4685,8 @@ function renderExpectedAnswerNote() {
               "div",
               { style: { fontSize: "14px", color: "#4b5d6f" } },
               lang === "en"
-                ? "AI details are available for download as a report file."
-                : "פרטי משוב ה-AI זמינים להורדה כקובץ דוח."
+                ? "The same report is shown in the summary above. You can also download a Word file to share."
+                : "אותו דוח מוצג למעלה בסיכום. אפשר גם להוריד קובץ Word לשיתוף."
             ),
             React.createElement(
               "div",


### PR DESCRIPTION
1. On session completion, render the expression AI feedback table (parent answer/score, AI score, match, reason, listen + match count) **inside** the immediate summary card below the donut cards when expression AI is resolved, sharing row logic with the Word export; added scrollable table styling in `styles.css` and clarified the Word button copy as optional download for devices that do not open `.doc` well.
2. Updated the inline completion-screen expression AI table to remove the per-row **Match** column (while keeping the top-level `x / y` match count), and expanded the **Reason** header width to use that freed space for better readability on phones.
3. Persisted `lastCompletedTestId` and `expressionAiResult` via `usePersistentState` in `test.js` so refreshing on the completion screen retains the saved AI feedback/summary state without storing large audio blobs in local storage.
4. Increased backend expression AI daily quota default by changing `GEMINI_DAILY_LIMIT` fallback in `backend/server.py` from `100` to `150` (still overridable by env var).
5. Updated the app footer label in `frontend_demo/app.js` from `version 3` to `version 3.1`.