### PR TITLE
resumebug and detail button removalon the summary screen

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -41,7 +41,7 @@ database_name = os.environ.get("DATABASE_NAME")
 
 # Initialize MongoDB storage manager
 storage = SeeSayMongoStorage(mongodb_url, database_name)
-GEMINI_DAILY_LIMIT = int(os.environ.get("GEMINI_DAILY_LIMIT", "200"))
+GEMINI_DAILY_LIMIT = int(os.environ.get("GEMINI_DAILY_LIMIT", "350"))
 _raw_max_seg = int(os.environ.get("GEMINI_MAX_SEGMENT_SECONDS", "30"))
 # Keep server trim cap >= frontend expression window (30s). Older .env files used 20.
 if _raw_max_seg < 30:
@@ -56,7 +56,7 @@ logger.info(
     "(override with env GEMINI_MAX_SEGMENT_SECONDS; minimum 30)",
     GEMINI_MAX_SEGMENT_SECONDS,
 )
-GEMINI_IMPRESSION_DAILY_LIMIT = int(os.environ.get("GEMINI_IMPRESSION_DAILY_LIMIT", "200"))
+GEMINI_IMPRESSION_DAILY_LIMIT = int(os.environ.get("GEMINI_IMPRESSION_DAILY_LIMIT", "350"))
 GEMINI_IMPRESSION_MAX_OUTPUT_TOKENS = int(os.environ.get("GEMINI_IMPRESSION_MAX_OUTPUT_TOKENS", "2800"))
 EXPRESSION_IMPRESSION_SAMPLE_CAP = int(os.environ.get("EXPRESSION_IMPRESSION_SAMPLE_CAP", "10"))
 

--- a/changes/CHANGES_2026-05-14_15-05.md
+++ b/changes/CHANGES_2026-05-14_15-05.md
@@ -10,10 +10,9 @@ Expression-only incremental audio: plan, first full-stack slice (draft / clips /
 
 ## Summary (2-3 bullets)
 
-- **Docs & plan:** Expression-only incremental-audio plan under **`docs/plans/`** (glossary, **30s** clip semantics, resume/refresh, execution todos including **client auto-stop**, and observability for Gemini, caps, and troubleshooting).
-- **Backend:** Draft test + **`expressionClip`** + **`finalizeTest`** on **`server.py`** / **`MongoDB.py`**, **30s** clip trim aligned to **`GEMINI_MAX_SEGMENT_SECONDS`**, monotonic finalize progress, legacy **`addTestToUser`** defaults, richer **INFO** logging for clips and Gemini, and expression rubrics/impression metadata aligned to CSV **`category_PLS`** / **`sub_category_PLS`** (legacy **`semantics`** / **`category PLS`** still read when present).
-- **Frontend:** Session timeline and draft flow without comprehension **`MediaRecorder`** buffering; expression clips with **pause-aware 30s active-time client cap**, worker **MP3** path, **`postExpressionClipWithRetry`** + **`runWithExpressionClipConcurrency`** + **`finalizeUserTestsWithRetry`**, **`sessionGoHomeBlock`** overlays, summary **expressionAi** polling/progress fixes, handoff yields before encode, **try_again** feedback without random alternates, and **expression traffic countdown frozen** during streak clapping.
-- **Impression:** One Gemini call now includes **all comprehension** results (grouped correct/partly/wrong with **`category_PLS`** / **`sub_category_PLS`** from server CSV) plus up to **10** expression audio samples — no extra per-question comprehension API calls.
+- **Docs & plan:** Expression-only incremental-audio plan under **`docs/plans/`** (glossary, **30s** clip semantics, resume/refresh, client auto-stop, and Gemini observability).
+- **Backend:** Draft **`expressionClip`** / **`finalizeTest`**, **30s** trim, monotonic finalize progress, **comprehension + expression** impression in one Gemini call, rubrics on CSV **`category_PLS`** / **`sub_category_PLS`**, and daily quotas **`GEMINI_DAILY_LIMIT`** / **`GEMINI_IMPRESSION_DAILY_LIMIT`** default **350**.
+- **Frontend:** Expression clips with pause-aware **30s** cap, **question-tagged** post-cap cache, worker **MP3**, reliable clip/finalize uploads, summary **expressionAi** progress, and traffic countdown pause/resume aligned with recording.
 
 ## numbered main changes
 
@@ -70,6 +69,9 @@ Expression-only incremental audio: plan, first full-stack slice (draft / clips /
 51. [`frontend_demo/app.js`](frontend_demo/app.js): Footer **`app-version-label`** updated from **version 3.2** to **version 3.3**.
 52. [`frontend_demo/test.js`](frontend_demo/test.js): Expression popup **30s timer** and **traffic-open timeout** now **pause and resume** together (clear/reschedule enable timer on pause; full remaining time after resume).
 53. [`frontend_demo/recording.js`](frontend_demo/recording.js) + [`frontend_demo/test.js`](frontend_demo/test.js): Expression **clip active-time cap** freezes on test pause/clapping, aligns to **UI seconds left + grace** on resume; test pause always calls **`pauseRecording`** (draft clip-only path); auto-stop no longer fires while recorder is **paused**.
+54. [`frontend_demo/test.js`](frontend_demo/test.js): Removed **detailed results** download button and **`downloadTimestamps`** handler from the session-complete summary screen.
+55. [`frontend_demo/recording.js`](frontend_demo/recording.js) + [`frontend_demo/test.js`](frontend_demo/test.js): Expression clip cache is **tagged by `question_number`** — reuse only for the **same** question after **30s cap**; **discard** on **`loadQuestion`**, after traffic upload **`finally`**, and when arming a **different** question (fixes Q1 audio scored as Q2 without reviving null blob after cap).
+56. [`backend/server.py`](backend/server.py): Raised default **`GEMINI_DAILY_LIMIT`** and **`GEMINI_IMPRESSION_DAILY_LIMIT`** from **200** to **350** (still overridable via environment).
 
 ## numbered notes
 
@@ -87,3 +89,5 @@ Expression-only incremental audio: plan, first full-stack slice (draft / clips /
 12. **`postExpressionClipWithRetry`** does not retry **404** or other non-retryable **4xx**; repeated failures add backoff delay before the go-home **`clipSave`** path runs.
 13. **`finalizeUserTestsWithRetry`** uses the same transient-retry policy as clips; **`finalizeUserTests`** (non-draft callers) stays single-attempt via **`finalizeUserTestsCore`**.
 14. Expression clip **client cap** defaults to **30s** of **active** recording (elapsed time while **recording** reduces the remaining budget; pause does not extend the window); override **`window.SEEANDSAY_EXPRESSION_CLIP_MAX_SECONDS`** only for QA and keep it aligned with **`GEMINI_MAX_SEGMENT_SECONDS`** when testing trim parity.
+15. After **30s cap**, traffic submit still uses **`stopExpressionClipRecording`** → **`takeCachedExpressionClipBlob`** (or await **`expressionClipStopPromise`** while encoding); **`discardCachedExpressionClipBlob`** runs only after upload **`finally`** or on **question change**, not while the same question waits on the traffic popup.
+16. **`GEMINI_DAILY_LIMIT`** / **`GEMINI_IMPRESSION_DAILY_LIMIT`** count resets per **UTC** calendar day in Mongo; restarting uvicorn applies the new **350** default only when those env vars are unset.

--- a/frontend_demo/recording.js
+++ b/frontend_demo/recording.js
@@ -27,6 +27,9 @@ const SessionRecorder = (function() {
    * without this cache — causing missing_clip_at_finalize on the server.
    */
   let cachedExpressionClipBlob = null;
+  /** Question id the cached blob belongs to (same-question reuse after 30s cap only). */
+  let cachedExpressionClipQuestion = null;
+  let expressionClipActiveQuestion = null;
   
   // Question timestamps tracking
   let recordingStartTime = null;
@@ -664,7 +667,18 @@ const SessionRecorder = (function() {
     );
   }
 
-  async function startExpressionClipRecording() {
+  function discardCachedExpressionClipBlob() {
+    cachedExpressionClipBlob = null;
+    cachedExpressionClipQuestion = null;
+  }
+
+  async function startExpressionClipRecording(questionNumber) {
+    var qKey =
+      questionNumber != null && questionNumber !== ""
+        ? String(questionNumber)
+        : null;
+    expressionClipActiveQuestion = qKey;
+
     if (expressionMediaRecorder && expressionMediaRecorder.state === "recording") {
       return true;
     }
@@ -675,10 +689,27 @@ const SessionRecorder = (function() {
       } catch (e) {}
     }
     if (cachedExpressionClipBlob && cachedExpressionClipBlob.size > 0) {
-      console.log("🎙️ Expression clip: cached blob ready (waiting for traffic submit)");
-      return true;
+      if (qKey && cachedExpressionClipQuestion === qKey) {
+        console.log("🎙️ Expression clip: cached blob ready (waiting for traffic submit)");
+        return true;
+      }
+      if (qKey && cachedExpressionClipQuestion && cachedExpressionClipQuestion !== qKey) {
+        console.warn(
+          "🎙️ Expression clip: discarding cached blob for question",
+          cachedExpressionClipQuestion,
+          "(now on question",
+          qKey + ")"
+        );
+        discardCachedExpressionClipBlob();
+      } else if (!qKey) {
+        console.log("🎙️ Expression clip: cached blob ready (waiting for traffic submit)");
+        return true;
+      } else if (qKey && !cachedExpressionClipQuestion) {
+        console.warn("🎙️ Expression clip: discarding untagged cached blob before question", qKey);
+        discardCachedExpressionClipBlob();
+      }
     }
-    cachedExpressionClipBlob = null;
+    discardCachedExpressionClipBlob();
     resetExpressionClipAutoStopScheduling();
     try {
       const userStream = await navigator.mediaDevices.getUserMedia({ audio: true });
@@ -711,6 +742,7 @@ const SessionRecorder = (function() {
           mp3Blob = originalBlob;
         }
         cachedExpressionClipBlob = mp3Blob && mp3Blob.size > 0 ? mp3Blob : null;
+        cachedExpressionClipQuestion = expressionClipActiveQuestion;
         if (expressionStopResolve) {
           expressionStopResolve(mp3Blob);
           expressionStopResolve = null;
@@ -740,7 +772,7 @@ const SessionRecorder = (function() {
       return null;
     }
     var blob = cachedExpressionClipBlob;
-    cachedExpressionClipBlob = null;
+    discardCachedExpressionClipBlob();
     return blob;
   }
 
@@ -1147,7 +1179,8 @@ const SessionRecorder = (function() {
     expressionClipSegmentStartedAt = null;
     expressionClipAutoStopRemainingMs = null;
     expressionClipStopPromise = null;
-    cachedExpressionClipBlob = null;
+    discardCachedExpressionClipBlob();
+    expressionClipActiveQuestion = null;
     if (expressionMediaRecorder && expressionMediaRecorder.state !== "inactive") {
       var pendingResolve = expressionStopResolve;
       expressionStopResolve = null;
@@ -1222,6 +1255,7 @@ const SessionRecorder = (function() {
     initSessionTimelineClock: initSessionTimelineClock,
     startExpressionClipRecording: startExpressionClipRecording,
     stopExpressionClipRecording: stopExpressionClipRecording,
+    discardCachedExpressionClipBlob: discardCachedExpressionClipBlob,
     isExpressionClipRecording: isExpressionClipRecording,
     isExpressionClipActive: isExpressionClipActive,
     freezeExpressionClipActiveCap: freezeExpressionClipActiveCap,

--- a/frontend_demo/test.js
+++ b/frontend_demo/test.js
@@ -1522,8 +1522,11 @@ const handleReadingValidationRetry = function () {
     if (!draftTestId) return;
     var SR = window.SessionRecorder;
     if (!SR || typeof SR.startExpressionClipRecording !== "function") return;
+    var idx = getSafeCurrentQuestionIndex();
+    var qForClip = questions[idx];
+    var qNum = qForClip && qForClip.query_number != null ? qForClip.query_number : null;
     (async function () {
-      await SR.startExpressionClipRecording();
+      await SR.startExpressionClipRecording(qNum);
     })();
   }, [
     expressionEvalArmed,
@@ -1760,6 +1763,14 @@ const handleReadingValidationRetry = function () {
             setSessionGoHomeBlock("clipSave");
           }
           return null;
+        })
+        .finally(function () {
+          if (
+            SessionRecorder &&
+            SessionRecorder.discardCachedExpressionClipBlob
+          ) {
+            SessionRecorder.discardCachedExpressionClipBlob();
+          }
         });
       clipUploadPromisesRef.current.push(uploadP);
       finishTraffic();
@@ -2832,6 +2843,13 @@ const handleReadingValidationRetry = function () {
   function loadQuestion(index) {
     const q = questions[index];
     if (!q) return;
+
+    if (
+      SessionRecorder &&
+      SessionRecorder.discardCachedExpressionClipBlob
+    ) {
+      SessionRecorder.discardCachedExpressionClipBlob();
+    }
 
     questionAudioAutoplayPendingRef.current = false;
     if (questionAudioRef.current) {
@@ -4384,51 +4402,6 @@ function renderExpectedAnswerNote() {
       return "—";
     }
 
-    // Download timestamp file function (enhanced with question results and transcription)
-    const downloadTimestamps = function () {
-      // Get timestamp text from SessionRecorder
-      const timestampText = SessionRecorder.getTimestampText();
-      
-      // Format question results array
-      const questionResultsText = formatQuestionResultsArray(questionResults);
-      
-      // Build the complete text file content
-      let fileContent = "";
-      
-      // Add timestamps section
-      fileContent += "=== Question Timestamps ===\n";
-      fileContent += timestampText + "\n\n";
-      
-      // Add question results section
-      fileContent += "=== Question Results ===\n";
-      fileContent += "Format: [(questionNumber,\"result\"), ...]\n";
-      fileContent += "Results: correct, partly, wrong\n";
-      fileContent += questionResultsText + "\n\n";
-      
-      // Add transcription section if available
-      if (transcription) {
-        fileContent += "=== Transcription ===\n";
-        fileContent += transcription + "\n";
-      } else {
-        fileContent += "=== Transcription ===\n";
-        fileContent += "Transcription not available yet.\n";
-      }
-      
-      // Create and download the file
-      const blob = new Blob([fileContent], { type: "text/plain" });
-      const url = URL.createObjectURL(blob);
-      
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = "session_data_" + idDigits + "_" + Date.now() + ".txt";
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-      
-      console.log("📥 Downloaded session data file with timestamps, results, and transcription");
-    };
-
     const parentStatusForReport = function (parentResult) {
       if (parentResult === "correct") return lang === "en" ? "Success" : "הצליח";
       if (parentResult === "partly") return lang === "en" ? "Partial" : "חלקי";
@@ -5065,29 +5038,7 @@ function renderExpectedAnswerNote() {
               )
             )
           )
-        : null,
-      // Download buttons: timestamps export only (session audio is stored per expression clip server-side).
-      React.createElement(
-        "div",
-        { style: { marginTop: "20px", display: "flex", gap: "10px", justifyContent: "center", flexWrap: "wrap" } },
-        React.createElement(
-          "button",
-          {
-            style: {
-              padding: "10px 20px",
-              fontSize: "16px",
-              backgroundColor: "#4CAF50",
-              color: "white",
-              border: "none",
-              borderRadius: "8px",
-              cursor: "pointer",
-              opacity: 1
-            },
-            onClick: downloadTimestamps
-          },
-          tr("test.done.downloadTimestamps")
-        )
-      )
+        : null
       )
     );
   }


### PR DESCRIPTION
1. [`frontend_demo/test.js`](frontend_demo/test.js): Removed **detailed results** download button and **`downloadTimestamps`** handler from the session-complete summary screen.
2. [`frontend_demo/recording.js`](frontend_demo/recording.js) + [`frontend_demo/test.js`](frontend_demo/test.js): Expression clip cache is **tagged by `question_number`** — reuse only for the **same** question after **30s cap**; **discard** on **`loadQuestion`**, after traffic upload **`finally`**, and when arming a **different** question (fixes Q1 audio scored as Q2 without reviving null blob after cap).
3. [`backend/server.py`](backend/server.py): Raised default **`GEMINI_DAILY_LIMIT`** and **`GEMINI_IMPRESSION_DAILY_LIMIT`** from **200** to **350** (still overridable via environment).