### PR TITLE
expquestion delay to prevent audio glitch

### DIFF
--- a/changes/CHANGES_2026-05-14_15-05.md
+++ b/changes/CHANGES_2026-05-14_15-05.md
@@ -12,7 +12,7 @@ Expression-only incremental audio: plan, first full-stack slice (draft / clips /
 
 - **Docs & plan:** Expression-only incremental-audio plan under **`docs/plans/`** (glossary, **30s** clip semantics, resume/refresh, client auto-stop, and Gemini observability).
 - **Backend:** Draft **`expressionClip`** / **`finalizeTest`**, **30s** trim, monotonic finalize progress, **comprehension + expression** impression in one Gemini call, rubrics on CSV **`category_PLS`** / **`sub_category_PLS`**, and daily quotas **`GEMINI_DAILY_LIMIT`** / **`GEMINI_IMPRESSION_DAILY_LIMIT`** default **350**.
-- **Frontend:** Expression clips with pause-aware **30s** cap, **question-tagged** post-cap cache, worker **MP3**, reliable clip/finalize uploads, summary **expressionAi** progress, and traffic countdown pause/resume aligned with recording.
+- **Frontend:** Expression clips with pause-aware **30s** cap and gated encode queue; question MP3 playback waits for **`canplaythrough`** on every question (autoplay/replay); question-tagged clip cache; reliable clip/finalize uploads.
 
 ## numbered main changes
 
@@ -72,6 +72,9 @@ Expression-only incremental audio: plan, first full-stack slice (draft / clips /
 54. [`frontend_demo/test.js`](frontend_demo/test.js): Removed **detailed results** download button and **`downloadTimestamps`** handler from the session-complete summary screen.
 55. [`frontend_demo/recording.js`](frontend_demo/recording.js) + [`frontend_demo/test.js`](frontend_demo/test.js): Expression clip cache is **tagged by `question_number`** — reuse only for the **same** question after **30s cap**; **discard** on **`loadQuestion`**, after traffic upload **`finally`**, and when arming a **different** question (fixes Q1 audio scored as Q2 without reviving null blob after cap).
 56. [`backend/server.py`](backend/server.py): Raised default **`GEMINI_DAILY_LIMIT`** and **`GEMINI_IMPRESSION_DAILY_LIMIT`** from **200** to **350** (still overridable via environment).
+57. [`frontend_demo/recording.js`](frontend_demo/recording.js) + [`frontend_demo/test.js`](frontend_demo/test.js): **Encode queue** (one MP3 at a time, max **2** waiting) runs after **`setQuestionReadingActive(false)`**; queue overflow encodes one clip during reading; **`flushExpressionClipEncodeQueue`** on session end; question MP3 **`preload="auto"`**.
+58. [`frontend_demo/test.js`](frontend_demo/test.js): All question readings wait for **`canplaythrough`** ( **`loadeddata`** + timeout fallback) via **`playAudioWhenReady`** before **`play()`** — autoplay, replay button, and first-question retries; **`audio.load()`** on each new question element.
+59. [`frontend_demo/recording.js`](frontend_demo/recording.js) + [`frontend_demo/test.js`](frontend_demo/test.js): **Expression (הבעה)** questions wait **1s** (override **`SEEANDSAY_EXPRESSION_QUESTION_AUDIO_DELAY_MS`**) before reading starts, draining pending clip encodes in that gap; encode no longer starts on **`loadQuestion`** alone; clip upload defers base64 work by the same gap after traffic.
 
 ## numbered notes
 
@@ -91,3 +94,5 @@ Expression-only incremental audio: plan, first full-stack slice (draft / clips /
 14. Expression clip **client cap** defaults to **30s** of **active** recording (elapsed time while **recording** reduces the remaining budget; pause does not extend the window); override **`window.SEEANDSAY_EXPRESSION_CLIP_MAX_SECONDS`** only for QA and keep it aligned with **`GEMINI_MAX_SEGMENT_SECONDS`** when testing trim parity.
 15. After **30s cap**, traffic submit still uses **`stopExpressionClipRecording`** → **`takeCachedExpressionClipBlob`** (or await **`expressionClipStopPromise`** while encoding); **`discardCachedExpressionClipBlob`** runs only after upload **`finally`** or on **question change**, not while the same question waits on the traffic popup.
 16. **`GEMINI_DAILY_LIMIT`** / **`GEMINI_IMPRESSION_DAILY_LIMIT`** count resets per **UTC** calendar day in Mongo; restarting uvicorn applies the new **350** default only when those env vars are unset.
+17. Expression clip **upload** concurrency (default **2** in **`apiToMongo`**) is unchanged; only **MP3 encode** is serialized. Override encode queue depth with **`window.SEEANDSAY_EXPRESSION_CLIP_ENCODE_QUEUE_MAX`** (default **2**).
+18. MP3 **worker** only runs **lame** off-thread; **`decodeAudioData`** and **`readBlobAsDataURL`** still run on the main thread — expression read delay is intentional headroom for that work.

--- a/frontend_demo/recording.js
+++ b/frontend_demo/recording.js
@@ -105,6 +105,186 @@ const SessionRecorder = (function() {
     });
   }
 
+  /**
+   * Serialize expression-clip MP3 encode so decodeAudioData does not run during question <audio> playback.
+   * Max 2 waiting jobs; session end flushes all. Upload concurrency stays separate in apiToMongo.
+   */
+  var EXPRESSION_CLIP_ENCODE_QUEUE_MAX =
+    typeof window !== "undefined" && window.SEEANDSAY_EXPRESSION_CLIP_ENCODE_QUEUE_MAX != null
+      ? Math.max(1, parseInt(window.SEEANDSAY_EXPRESSION_CLIP_ENCODE_QUEUE_MAX, 10) || 2)
+      : 2;
+  var expressionClipEncodeQueue = [];
+  var expressionClipEncodeInProgress = false;
+  var questionReadingActive = false;
+
+  function setQuestionReadingActive(active) {
+    questionReadingActive = !!active;
+  }
+
+  /** Safe gap before expression question reading: drain pending clip encodes (not during playback). */
+  function drainExpressionClipEncodeBeforeRead() {
+    if (questionReadingActive) {
+      return Promise.resolve();
+    }
+    return tryProcessExpressionClipEncodeQueue();
+  }
+
+  function completeExpressionClipEncodeJob(job, mp3Blob) {
+    var out = mp3Blob && mp3Blob.size > 0 ? mp3Blob : null;
+    cachedExpressionClipBlob = out;
+    cachedExpressionClipQuestion =
+      job.questionNumber != null && job.questionNumber !== ""
+        ? String(job.questionNumber)
+        : expressionClipActiveQuestion;
+    if (typeof job.stopResolve === "function") {
+      try {
+        job.stopResolve(out);
+      } catch (e) {}
+      job.stopResolve = null;
+    }
+    if (typeof job.promiseResolve === "function") {
+      job.promiseResolve(out);
+      job.promiseResolve = null;
+    }
+  }
+
+  function processOneExpressionClipEncodeJob(options) {
+    options = options || {};
+    var bypassReadingGate = !!options.bypassReadingGate;
+    if (expressionClipEncodeInProgress) {
+      return Promise.resolve();
+    }
+    if (!bypassReadingGate && questionReadingActive) {
+      return Promise.resolve();
+    }
+    if (expressionClipEncodeQueue.length === 0) {
+      return Promise.resolve();
+    }
+    var job = expressionClipEncodeQueue.shift();
+    expressionClipEncodeInProgress = true;
+    return Promise.resolve()
+      .then(function () {
+        return yieldBeforeMp3Encode();
+      })
+      .then(function () {
+        return convertToMP3(job.webmBlob);
+      })
+      .then(function (mp3Blob) {
+        completeExpressionClipEncodeJob(job, mp3Blob);
+      })
+      .catch(function (e) {
+        console.error("Expression clip MP3 convert failed:", e);
+        completeExpressionClipEncodeJob(job, job.webmBlob);
+      })
+      .finally(function () {
+        expressionClipEncodeInProgress = false;
+        tryProcessExpressionClipEncodeQueue();
+      });
+  }
+
+  function tryProcessExpressionClipEncodeQueue(options) {
+    return processOneExpressionClipEncodeJob(options).then(function () {
+      if (
+        !expressionClipEncodeInProgress &&
+        expressionClipEncodeQueue.length > 0 &&
+        (!questionReadingActive || (options && options.bypassReadingGate))
+      ) {
+        return tryProcessExpressionClipEncodeQueue(options);
+      }
+    });
+  }
+
+  function waitForExpressionClipEncodeIdle() {
+    return new Promise(function (resolve) {
+      function tick() {
+        if (!expressionClipEncodeInProgress && expressionClipEncodeQueue.length === 0) {
+          resolve();
+          return;
+        }
+        if (!expressionClipEncodeInProgress && expressionClipEncodeQueue.length > 0) {
+          processOneExpressionClipEncodeJob({ bypassReadingGate: true }).then(tick).catch(tick);
+          return;
+        }
+        setTimeout(tick, 40);
+      }
+      tick();
+    });
+  }
+
+  function waitForCachedExpressionClipMp3(maxMs) {
+    var limit = maxMs == null ? 120000 : maxMs;
+    var started = Date.now();
+    return new Promise(function (resolve) {
+      function tick() {
+        if (cachedExpressionClipBlob && cachedExpressionClipBlob.size > 0) {
+          resolve(cachedExpressionClipBlob);
+          return;
+        }
+        if (!expressionClipEncodeInProgress && expressionClipEncodeQueue.length === 0) {
+          resolve(null);
+          return;
+        }
+        if (Date.now() - started > limit) {
+          console.warn("[See&Say] Timed out waiting for expression clip MP3 encode");
+          resolve(null);
+          return;
+        }
+        if (!expressionClipEncodeInProgress && !questionReadingActive) {
+          tryProcessExpressionClipEncodeQueue();
+        } else if (
+          !expressionClipEncodeInProgress &&
+          expressionClipEncodeQueue.length > 0
+        ) {
+          processOneExpressionClipEncodeJob({ bypassReadingGate: true });
+        }
+        setTimeout(tick, 50);
+      }
+      tick();
+    });
+  }
+
+  function enqueueExpressionClipEncode(webmBlob, questionNumber, stopResolve) {
+    return new Promise(function (resolve, reject) {
+      function pushJob() {
+        var job = {
+          webmBlob: webmBlob,
+          questionNumber:
+            questionNumber != null && questionNumber !== ""
+              ? String(questionNumber)
+              : expressionClipActiveQuestion,
+          stopResolve: stopResolve,
+          promiseResolve: resolve,
+          promiseReject: reject,
+        };
+        expressionClipEncodeQueue.push(job);
+        if (!questionReadingActive) {
+          tryProcessExpressionClipEncodeQueue();
+        }
+      }
+
+      function drainQueueSlotForIncomingJob() {
+        if (expressionClipEncodeQueue.length < EXPRESSION_CLIP_ENCODE_QUEUE_MAX) {
+          return Promise.resolve();
+        }
+        console.warn(
+          "[See&Say] Expression clip encode queue full (" +
+            EXPRESSION_CLIP_ENCODE_QUEUE_MAX +
+            "); encoding one clip during reading to make room"
+        );
+        return processOneExpressionClipEncodeJob({ bypassReadingGate: true }).then(
+          drainQueueSlotForIncomingJob
+        );
+      }
+
+      drainQueueSlotForIncomingJob().then(pushJob).catch(reject);
+    });
+  }
+
+  function flushExpressionClipEncodeQueue() {
+    questionReadingActive = false;
+    return waitForExpressionClipEncodeIdle();
+  }
+
   /** Lazy singleton; null = not created yet, false = unavailable or hard-failed. */
   let mp3Worker = null;
   let mp3WorkerJobId = 0;
@@ -732,21 +912,8 @@ const SessionRecorder = (function() {
           (expressionAudioChunks[0] && expressionAudioChunks[0].type) ||
           "audio/webm";
         const originalBlob = new Blob(expressionAudioChunks, { type: blobType });
-        var mp3Blob = null;
-        try {
-          await yieldForQuestionAudioHandoff();
-          await yieldBeforeMp3Encode();
-          mp3Blob = await convertToMP3(originalBlob);
-        } catch (e) {
-          console.error("Expression clip MP3 convert failed:", e);
-          mp3Blob = originalBlob;
-        }
-        cachedExpressionClipBlob = mp3Blob && mp3Blob.size > 0 ? mp3Blob : null;
-        cachedExpressionClipQuestion = expressionClipActiveQuestion;
-        if (expressionStopResolve) {
-          expressionStopResolve(mp3Blob);
-          expressionStopResolve = null;
-        }
+        var stopResolve = expressionStopResolve;
+        expressionStopResolve = null;
         expressionMediaRecorder = null;
         expressionAudioChunks = [];
         if (expressionStream) {
@@ -754,6 +921,18 @@ const SessionRecorder = (function() {
             track.stop();
           });
           expressionStream = null;
+        }
+        try {
+          await enqueueExpressionClipEncode(
+            originalBlob,
+            expressionClipActiveQuestion,
+            stopResolve
+          );
+        } catch (e) {
+          console.error("Expression clip encode enqueue failed:", e);
+          if (typeof stopResolve === "function") {
+            stopResolve(null);
+          }
         }
       };
       recorder.start(4000);
@@ -781,9 +960,20 @@ const SessionRecorder = (function() {
     expressionClipSegmentStartedAt = null;
     if (!expressionMediaRecorder || expressionMediaRecorder.state === "inactive") {
       resetExpressionClipAutoStopScheduling();
-      // Auto-stop may still be encoding MP3; traffic submit must await that, not return null.
+      // Await in-flight stop, queued encode, or cached MP3 (30s cap before traffic).
       if (expressionClipStopPromise) {
         return expressionClipStopPromise;
+      }
+      if (
+        expressionClipEncodeInProgress ||
+        expressionClipEncodeQueue.length > 0
+      ) {
+        return waitForCachedExpressionClipMp3().then(function (blob) {
+          if (blob) {
+            return takeCachedExpressionClipBlob() || blob;
+          }
+          return takeCachedExpressionClipBlob();
+        });
       }
       var cached = takeCachedExpressionClipBlob();
       if (cached) {
@@ -1181,6 +1371,9 @@ const SessionRecorder = (function() {
     expressionClipStopPromise = null;
     discardCachedExpressionClipBlob();
     expressionClipActiveQuestion = null;
+    expressionClipEncodeQueue = [];
+    expressionClipEncodeInProgress = false;
+    questionReadingActive = false;
     if (expressionMediaRecorder && expressionMediaRecorder.state !== "inactive") {
       var pendingResolve = expressionStopResolve;
       expressionStopResolve = null;
@@ -1256,6 +1449,9 @@ const SessionRecorder = (function() {
     startExpressionClipRecording: startExpressionClipRecording,
     stopExpressionClipRecording: stopExpressionClipRecording,
     discardCachedExpressionClipBlob: discardCachedExpressionClipBlob,
+    setQuestionReadingActive: setQuestionReadingActive,
+    drainExpressionClipEncodeBeforeRead: drainExpressionClipEncodeBeforeRead,
+    flushExpressionClipEncodeQueue: flushExpressionClipEncodeQueue,
     isExpressionClipRecording: isExpressionClipRecording,
     isExpressionClipActive: isExpressionClipActive,
     freezeExpressionClipActiveCap: freezeExpressionClipActiveCap,

--- a/frontend_demo/test.js
+++ b/frontend_demo/test.js
@@ -31,6 +31,202 @@ function Test({ allQuestions, lang, t, onHome, onReset, setLang, onTestPhase }) 
     });
   }
 
+  /**
+   * Wait for enough buffer before question MP3 play (all questions: autoplay + replay).
+   * Prefer canplaythrough; fallback after timeout if loadeddata is available.
+   */
+  function playAudioWhenReady(audioEl, options) {
+    options = options || {};
+    var timeoutMs = options.timeoutMs != null ? options.timeoutMs : 10000;
+    var isStale = options.isStale;
+
+    if (!audioEl) {
+      return Promise.resolve(null);
+    }
+
+    function canPlayThroughReady() {
+      return audioEl.readyState >= 4;
+    }
+
+    function hasLoadedData() {
+      return audioEl.readyState >= 2;
+    }
+
+    return new Promise(function (resolve) {
+      if (typeof isStale === "function" && isStale()) {
+        resolve(null);
+        return;
+      }
+      if (canPlayThroughReady()) {
+        resolve(audioEl.play());
+        return;
+      }
+
+      var settled = false;
+      function cleanup() {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timerId);
+        audioEl.removeEventListener("canplaythrough", onCanPlayThrough);
+        audioEl.removeEventListener("loadeddata", onLoadedData);
+      }
+      function tryPlay() {
+        if (typeof isStale === "function" && isStale()) {
+          cleanup();
+          resolve(null);
+          return;
+        }
+        cleanup();
+        try {
+          resolve(audioEl.play());
+        } catch (e) {
+          resolve(Promise.reject(e));
+        }
+      }
+      function onCanPlayThrough() {
+        tryPlay();
+      }
+      function onLoadedData() {
+        if (canPlayThroughReady()) {
+          tryPlay();
+        }
+      }
+
+      audioEl.addEventListener("canplaythrough", onCanPlayThrough);
+      audioEl.addEventListener("loadeddata", onLoadedData);
+      try {
+        if (audioEl.readyState === 0) {
+          audioEl.load();
+        }
+      } catch (eLoad) {}
+
+      var timerId = setTimeout(function () {
+        if (hasLoadedData()) {
+          console.warn(
+            "[See&Say] Question audio canplaythrough timeout; playing after loadeddata"
+          );
+        } else {
+          console.warn(
+            "[See&Say] Question audio still buffering; attempting play anyway"
+          );
+        }
+        tryPlay();
+      }, timeoutMs);
+    });
+  }
+
+  function applyQuestionAudioPlaySuccess(audioEl) {
+    if (!audioEl || questionAudioMuted) {
+      return;
+    }
+    if (questionAudioRef.current && questionAudioRef.current !== audioEl) {
+      return;
+    }
+    setIsAudioPlaying(true);
+  }
+
+  function handleQuestionAudioPlayFailure(err, audioEl, isFirstQuestion, questionNumber) {
+    console.warn("Question audio play failed:", err);
+    setIsAudioPlaying(false);
+    if (isFirstQuestion && audioEl) {
+      scheduleFirstQuestionAutoRetry(audioEl, questionNumber);
+    }
+  }
+
+  function getExpressionQuestionAudioDelayMs() {
+    if (
+      typeof window !== "undefined" &&
+      window.SEEANDSAY_EXPRESSION_QUESTION_AUDIO_DELAY_MS != null
+    ) {
+      var n = parseInt(window.SEEANDSAY_EXPRESSION_QUESTION_AUDIO_DELAY_MS, 10);
+      if (!Number.isNaN(n) && n >= 0) {
+        return n;
+      }
+    }
+    return 1000;
+  }
+
+  function delayMs(ms) {
+    return new Promise(function (resolve) {
+      setTimeout(resolve, Math.max(0, ms));
+    });
+  }
+
+  function isExpressionQuestionRow(q) {
+    return !!(q && q.query_type === "הבעה");
+  }
+
+  /**
+   * Expression (הבעה): wait so prior clip encode/upload can finish off the reading hot path,
+   * then play. Worker only encodes MP3; decodeAudioData + base64 upload still use main thread.
+   */
+  function prepareThenPlayQuestionAudio(audioEl, options) {
+    options = options || {};
+    var isFirstQuestionAutoplay = !!options.isFirstQuestionAutoplay;
+    var questionNumber =
+      options.questionNumber != null ? String(options.questionNumber) : "";
+    var q = options.question;
+
+    if (!audioEl || questionAudioMuted) {
+      return;
+    }
+    if (questionAudioRef.current !== audioEl) {
+      return;
+    }
+
+    function doPlay() {
+      if (questionAudioMuted || questionAudioRef.current !== audioEl) {
+        return;
+      }
+      if (
+        SessionRecorder &&
+        SessionRecorder.setQuestionReadingActive
+      ) {
+        SessionRecorder.setQuestionReadingActive(true);
+      }
+      audioEl.currentTime = 0;
+      playAudioWhenReady(audioEl, {
+        isStale: function () {
+          return questionAudioRef.current !== audioEl;
+        },
+      })
+        .then(function (playP) {
+          if (!playP) return;
+          if (playP && typeof playP.then === "function") {
+            return playP.then(function () {
+              applyQuestionAudioPlaySuccess(audioEl);
+            });
+          }
+          applyQuestionAudioPlaySuccess(audioEl);
+        })
+        .catch(function (err) {
+          handleQuestionAudioPlayFailure(
+            err,
+            audioEl,
+            isFirstQuestionAutoplay,
+            questionNumber
+          );
+        });
+    }
+
+    var gapMs = isExpressionQuestionRow(q) ? getExpressionQuestionAudioDelayMs() : 0;
+    var chain = Promise.resolve();
+    if (
+      gapMs > 0 &&
+      SessionRecorder &&
+      SessionRecorder.drainExpressionClipEncodeBeforeRead
+    ) {
+      chain = SessionRecorder.drainExpressionClipEncodeBeforeRead();
+    }
+    chain
+      .then(function () {
+        return delayMs(gapMs);
+      })
+      .then(doPlay);
+  }
+
   /** Set true to show the expression (הבעה) hint bulb + hint-driven scoring rules again. */
   var ENABLE_EXPRESSION_HINTS = false;
   var EXPRESSION_EVAL_DELAY_MS = 30000;
@@ -723,25 +919,27 @@ function blobToBase64(blob) {
       if (getSafeCurrentQuestionIndex() !== 0) return;
       if (questionAudioMuted || isPausedRef.current || sessionCompletedRef.current) return;
       if (!audioEl || questionAudioRef.current !== audioEl) return;
-      try {
-        audioEl.currentTime = 0;
-        var retryPlay = audioEl.play();
-        if (retryPlay && typeof retryPlay.then === "function") {
-          retryPlay.then(function () {
-            setIsAudioPlaying(true);
-            resetFirstQuestionRetryState();
-          }).catch(function () {
-            firstQuestionRetryAttemptRef.current = attempt + 1;
-            scheduleFirstQuestionAutoRetry(audioEl, qn);
-          });
-        } else {
-          setIsAudioPlaying(true);
+      audioEl.currentTime = 0;
+      playAudioWhenReady(audioEl, {
+        isStale: function () {
+          return questionAudioRef.current !== audioEl;
+        },
+      })
+        .then(function (retryPlay) {
+          if (!retryPlay) return;
+          if (retryPlay && typeof retryPlay.then === "function") {
+            return retryPlay.then(function () {
+              applyQuestionAudioPlaySuccess(audioEl);
+              resetFirstQuestionRetryState();
+            });
+          }
+          applyQuestionAudioPlaySuccess(audioEl);
           resetFirstQuestionRetryState();
-        }
-      } catch (e) {
-        firstQuestionRetryAttemptRef.current = attempt + 1;
-        scheduleFirstQuestionAutoRetry(audioEl, qn);
-      }
+        })
+        .catch(function () {
+          firstQuestionRetryAttemptRef.current = attempt + 1;
+          scheduleFirstQuestionAutoRetry(audioEl, qn);
+        });
     }, retryDelays[attempt]);
   }
 
@@ -1730,7 +1928,11 @@ const handleReadingValidationRetry = function () {
             }
             return null;
           }
-          return readBlobAsDataURL(blob).then(function (dataUrl) {
+          return delayMs(getExpressionQuestionAudioDelayMs()).then(function () {
+            return blob;
+          }).then(function (blobAfterGap) {
+            return readBlobAsDataURL(blobAfterGap);
+          }).then(function (dataUrl) {
             if (!dataUrl) return null;
             var tid = draftTestIdRef.current || tidForUpload;
             if (!tid) return null;
@@ -1832,11 +2034,14 @@ const handleReadingValidationRetry = function () {
   };
 
   const playQuestionAudio = function () {
-    if (questionAudio && !questionAudioMuted) {
-      questionAudio.currentTime = 0;
-      questionAudio.play();
-      setIsAudioPlaying(true);
-    }
+    var audioEl = questionAudioRef.current || questionAudio;
+    var idx = getSafeCurrentQuestionIndex();
+    var q = idx >= 0 ? questions[idx] : null;
+    prepareThenPlayQuestionAudio(audioEl, {
+      isFirstQuestionAutoplay: idx === 0,
+      questionNumber: q && q.query_number != null ? q.query_number : "",
+      question: q,
+    });
   };
 
   const replayQuestionAudio = function () {
@@ -1888,22 +2093,11 @@ const handleReadingValidationRetry = function () {
     var isFirstQuestionAutoplay = currentIdxForAutoplay === 0;
     var currentQuestionNumber = currentQuestion ? String(currentQuestion.query_number || "") : "";
     function runPlay() {
-      if (questionAudioMuted) return;
-      try {
-        audioEl.currentTime = 0;
-        audioEl.play().catch(function (err) {
-          console.warn("Audio autoplay failed:", err);
-          if (isFirstQuestionAutoplay) {
-            scheduleFirstQuestionAutoRetry(audioEl, currentQuestionNumber);
-          }
-        });
-        setIsAudioPlaying(true);
-      } catch (e) {
-        console.warn("Audio play error:", e);
-        if (isFirstQuestionAutoplay) {
-          scheduleFirstQuestionAutoRetry(audioEl, currentQuestionNumber);
-        }
-      }
+      prepareThenPlayQuestionAudio(audioEl, {
+        isFirstQuestionAutoplay: isFirstQuestionAutoplay,
+        questionNumber: currentQuestionNumber,
+        question: currentQuestion,
+      });
     }
 
     if (isFirstQuestionAutoplay && firstQuestionMicGateArmedRef.current) {
@@ -2850,6 +3044,12 @@ const handleReadingValidationRetry = function () {
     ) {
       SessionRecorder.discardCachedExpressionClipBlob();
     }
+    if (
+      SessionRecorder &&
+      SessionRecorder.setQuestionReadingActive
+    ) {
+      SessionRecorder.setQuestionReadingActive(false);
+    }
 
     questionAudioAutoplayPendingRef.current = false;
     if (questionAudioRef.current) {
@@ -3014,17 +3214,26 @@ const handleReadingValidationRetry = function () {
       const audioFolder = getQuestionAudioFolderByGender(childGender);
       const audioUrl = "resources/questions_audio/" + audioFolder + "/audio_" + q.query_number + ".mp3";
       const audio = new Audio(audioUrl);
-      audio.onended = function () {
+      audio.preload = "auto";
+      try {
+        audio.load();
+      } catch (eLoad) {}
+      function onQuestionReadingDone() {
         setIsAudioPlaying(false);
+        if (
+          SessionRecorder &&
+          SessionRecorder.setQuestionReadingActive
+        ) {
+          SessionRecorder.setQuestionReadingActive(false);
+        }
         if (q.query_type === "הבעה") {
           markExpressionTimestampAndArm(q);
         }
-      };
+      }
+      audio.onended = onQuestionReadingDone;
       audio.onerror = function () {
         console.warn('Audio file not found for question:', q.query_number);
-        if (q.query_type === "הבעה") {
-          markExpressionTimestampAndArm(q);
-        }
+        onQuestionReadingDone();
       };
       questionAudioRef.current = audio;
       setQuestionAudio(audio);
@@ -3156,6 +3365,16 @@ const handleReadingValidationRetry = function () {
     // Draft test: per-question expression clips + finalize (no monolithic session audio).
     if (draftTestId && permission && !microphoneSkipped) {
       (async function () {
+        if (
+          SessionRecorder &&
+          SessionRecorder.flushExpressionClipEncodeQueue
+        ) {
+          try {
+            await SessionRecorder.flushExpressionClipEncodeQueue();
+          } catch (e) {
+            console.warn("flushExpressionClipEncodeQueue:", e);
+          }
+        }
         if (SessionRecorder.stopExpressionClipRecording) {
           try {
             var stray = await SessionRecorder.stopExpressionClipRecording();


### PR DESCRIPTION
1. [`frontend_demo/test.js`](frontend_demo/test.js): All question readings wait for **`canplaythrough`** ( **`loadeddata`** + timeout fallback) via **`playAudioWhenReady`** before **`play()`** — autoplay, replay button, and first-question retries; **`audio.load()`** on each new question element.
2. [`frontend_demo/recording.js`](frontend_demo/recording.js) + [`frontend_demo/test.js`](frontend_demo/test.js): **Expression (הבעה)** questions wait **1s** (override **`SEEANDSAY_EXPRESSION_QUESTION_AUDIO_DELAY_MS`**) before reading starts, draining pending clip encodes in that gap; encode no longer starts on **`loadQuestion`** alone; clip upload defers base64 work by the same gap after traffic.
