### PR TITLE
iosbug

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ flowchart LR
    - `incremental`: each expression question creates a short segment and queues background upload/scoring.
 4. **Finish**
    - `legacy`: `prepareUpload` → upload `session.mp3` → `addTestToUser` with timestamps.
-   - `incremental`: enqueue last segment before advance/finish, drain upload queue (up to 60s), then `addTestToUser` metadata-only finalize (no full session blob); release mic on success; reconcile score counters from deduped results.
+   - `incremental`: enqueue last segment before advance/finish, optional 30s finish retry burst for failed uploads, drain upload queue (up to 60s), then `addTestToUser` metadata-only finalize (always, even when zero segments uploaded); release mic on success; reconcile score counters from deduped results.
 5. **Background** — server runs expression AI (Gemini) from full-session slices (`legacy`) or per-question segments (`incremental`). Incremental finalize waits for all expression rows (retries + `processing_failed` fallback), then builds impression; optional SMS when AI is `done`.
 6. **Summary** — client polls `GET /api/expressionAiStatus`; summary UI completes only on terminal `done` with full progress (or explicit fallbacks).
 7. **SMS results link** — `?t=` / `?results=` opens token results (`MiliResultsView`) without login. Normal app open without a token always lands on welcome/home (stale `localStorage.page === "results"` does not block the game; test resume keys are unchanged).
@@ -111,7 +111,7 @@ On localhost, [`apiToMongo.js`](frontend_demo/js/api/apiToMongo.js) uses port **
 | **API** | [`backend/docs/BACKEND_MODULE_MAP.md`](backend/docs/BACKEND_MODULE_MAP.md) |
 | Backend layout & rules | [`backend/docs/BACKEND_STRUCTURE.md`](backend/docs/BACKEND_STRUCTURE.md) |
 | SMS + token results | [`backend/docs/SMS_RESULTS.md`](backend/docs/SMS_RESULTS.md) |
-| Recent engineering changes | [`changes/CHANGES_2026-05-28_28.md`](changes/CHANGES_2026-05-28_28.md) (incremental pipeline, interrupt recovery, results routing) |
+| Recent engineering changes | [`changes/CHANGES_2026-05-30_30.md`](changes/CHANGES_2026-05-30_30.md) (iOS segment upload retry); [`changes/CHANGES_2026-05-28_28.md`](changes/CHANGES_2026-05-28_28.md) (incremental pipeline, interrupt recovery) |
 
 ---
 
@@ -167,16 +167,17 @@ Rubrics are read from **`frontend_demo/resources/query_database.csv`** at startu
 
 ## Incremental expression (May 2026 highlights)
 
-Client footer / `MILI_APP_VERSION`: **5.4**. Login persists `expressionAudioMode` (`legacy` | `incremental`).
+Client footer / `MILI_APP_VERSION`: **5.6**. Login persists `expressionAudioMode` (`legacy` | `incremental`).
 
 | Area | Behavior |
 |------|----------|
-| During test | Per-question segment recorder + upload queue; 20s countdown freezes during segment upload drain and on segment interrupt |
+| During test | Per-question segment recorder + upload queue (3 retries per question, Q-keyed blob retention); 20s countdown freezes during segment upload drain and on segment interrupt |
 | Mic / call loss | Incremental-only full-screen interrupt + per-question re-record (blocked after server register); mic probe at timer arm if mic was off during prompt; legacy `recordingInterruptedBanner` unchanged for legacy mode |
-| Finish | Queue idle before metadata finalize; `releaseCaptureStream` on incremental success; session score counters reconciled at finish |
+| Finish | 30s finish retry burst (failed uploads only), then 60s queue drain, always metadata finalize; `releaseCaptureStream` on incremental success; session score counters reconciled at finish; `clientInfo.segmentUpload` for ops |
+| Summary / AI | Expression AI polling and summary gating unchanged — no 30s cap on feedback or impression display |
 | Results URL | `?t=` shows SMS results; opening the game without a token does not stick on “results not found” |
 
-Details and QA notes: [`changes/CHANGES_2026-05-28_28.md`](changes/CHANGES_2026-05-28_28.md).
+Details and QA notes: [`changes/CHANGES_2026-05-30_30.md`](changes/CHANGES_2026-05-30_30.md).
 
 ---
 

--- a/backend/docs/BACKEND_MODULE_MAP.md
+++ b/backend/docs/BACKEND_MODULE_MAP.md
@@ -40,7 +40,7 @@ flowchart TB
 1. **Login** — `POST /api/createUser` → `MongoDB.add_user` (optional `parentPhone`; `clientInfo.expressionAudioMode` from frontend).
 2. **During test (incremental)** — `POST /api/tests/prepareSegmentUpload` → SAS; **PUT** segment blob; `POST /api/tests/expressionSegment` → `MongoDB.upsert_expression_segment` (per question).
 3. **Finish (legacy)** — `POST /api/tests/prepareUpload` → SAS; browser **PUT** `session.mp3`; `POST /api/addTestToUser` → save test + queue expression AI from full session.
-4. **Finish (incremental)** — client drains segment queue, then `POST /api/addTestToUser` metadata-only; `_ensure_incremental_expression_rows_complete` (retries, `processing_failed` fallback) before impression; optional results SMS when `done`.
+4. **Finish (incremental)** — client finish retry burst (30s, failed uploads) + segment queue drain (60s), then `POST /api/addTestToUser` metadata-only with optional `clientInfo.segmentUpload`; `_ensure_incremental_expression_rows_complete` (retries, `processing_failed` fallback) before impression; optional results SMS when `done`.
 5. **Background** — `_run_expression_ai_background` → Gemini per-question scores + Hebrew impression.
 6. **Summary poll** — `GET /api/expressionAiStatus?userId&testId`
 7. **Public results** — `GET /api/results/by-token?t=...` → `MongoDB.find_test_by_results_token` (410 when expired).

--- a/backend/docs/README.md
+++ b/backend/docs/README.md
@@ -19,6 +19,7 @@ The frontend sends `clientInfo.expressionAudioMode` from login (`legacy` or `inc
 - **`incremental`**
   - Expression questions upload short per-question audio segments during the test.
   - Segment flow uses `POST /api/tests/prepareSegmentUpload` + blob PUT + `POST /api/tests/expressionSegment` (idempotent per-question upsert in Mongo).
+  - Client retries failed segment uploads up to 3 times per question; `clientInfo.segmentUpload` at finalize records per-question upload state for ops.
   - Draft shell tests can be created early; segments merge on finalize.
   - Finish still calls `POST /api/addTestToUser` but does **metadata-only** finalize (no full session blob required).
   - Before impression build, `_ensure_incremental_expression_rows_complete` waits for all expression rows (`retrying_missing` phase), with configurable retries and `processing_failed` fallback (`ai_score` 1) when scoring cannot complete.
@@ -32,7 +33,7 @@ The frontend sends `clientInfo.expressionAudioMode` from login (`legacy` or `inc
 | `INCREMENTAL_SCORE_RETRY_ATTEMPTS` | `5` | Retries while expression rows are missing at finalize |
 | `INCREMENTAL_SCORE_RETRY_DELAY_SEC` | `2` | Delay between retries |
 
-See [BACKEND_MODULE_MAP.md](BACKEND_MODULE_MAP.md) for route-level details and `server.py` ownership. Frontend interrupt/recovery and results routing: [`../../changes/CHANGES_2026-05-28_28.md`](../../changes/CHANGES_2026-05-28_28.md).
+See [BACKEND_MODULE_MAP.md](BACKEND_MODULE_MAP.md) for route-level details and `server.py` ownership. Frontend upload retry and finish recovery: [`../../changes/CHANGES_2026-05-30_30.md`](../../changes/CHANGES_2026-05-30_30.md). Prior incremental work: [`../../changes/CHANGES_2026-05-28_28.md`](../../changes/CHANGES_2026-05-28_28.md).
 
 **Run locally:** from `backend/`, activate venv, set `.env`, then:
 

--- a/changes/CHANGES_2026-05-30_30.md
+++ b/changes/CHANGES_2026-05-30_30.md
@@ -1,0 +1,27 @@
+## PR title
+
+iOS incremental segment upload network retry and finish recovery
+
+## Summary (2-3 bullets)
+
+- Hardened incremental expression segment uploads against iOS call and flaky-network failures with Q-keyed blob retention (`pendingUploads`) and up to three client retries per question (1s/2s backoff).
+- Finish always proceeds via incremental metadata finalize after a 60s queue drain plus a 30s finish retry burst for failed uploads only; summary and AI polling remain uncapped until full `done`.
+- Bumped app to 5.6; added `clientInfo.segmentUpload` debug stats; synced READMEs across root, frontend, and backend docs.
+
+## numbered main changes
+
+1. Added `pendingUploads[questionNumber]` map in `expressionSegmentUploadQueue.js` so segment blobs are retained until `registerExpressionSegment` succeeds (Option B).
+2. Added per-question upload retry (max 3 attempts, 1s/2s backoff) on prepare, PUT, and register failures; `exhausted` state when attempts are used up.
+3. Extended queue API with `getSegmentUploadClientInfo()`, `runFinishRetryBurst(30000)`, enriched `stats()` / `getQuestionUploadState`, and `cancelPendingForQuestion` clearing the pending map.
+4. Updated `testSessionFinish.js`: finish retry burst (30s, failed uploads only), keep 60s main queue drain, remove `completed > 0` legacy full-audio fallback, always incremental metadata finalize.
+5. Threaded `clientInfo.segmentUpload` at finalize via `updateUserTests` → `collectClientInfo` in `apiToMongo.js`.
+6. Wired queue helpers in `test.js` (`getExpressionSegmentUploadClientInfo`, `runExpressionSegmentFinishRetryBurst`).
+7. Bumped app footer and `MILI_APP_VERSION` to **5.6** in `app.js` and `apiToMongo.js`.
+8. Updated `README.md`, `frontend_demo/README.md`, `backend/docs/README.md`, `backend/docs/BACKEND_MODULE_MAP.md`, and `frontend_demo/docs/TEST_MODULE_MAP.md` for retry/finish behavior and May 30 changelog link.
+
+## numbered notes
+
+1. Re-test iPhone 15 + Chrome with incoming call during expression (e.g. Q33–39); compare `clientInfo.segmentUpload.byQuestion` vs Mongo `expressionSegments`.
+2. Parent UI unchanged when upload exhausts retries: server `processing_failed` row with Hebrew observation from `_build_processing_failed_expression_row`.
+3. The 30s cap applies only to the finish retry burst for failed uploads, not to expression AI polling or summary display (no partial impression after 30s).
+4. Visibility-based upload retry intentionally not primary (iOS Chrome often stays `visible` during calls).

--- a/frontend_demo/README.md
+++ b/frontend_demo/README.md
@@ -84,7 +84,7 @@ index.html
 
 **Resume:** `MiliTestRun` (in `app.js`) detects an in-progress run before login or when starting from home. Welcome can show “continue vs new game”; the test can restore index and scores. Mid-test resume keys are **not** cleared when fixing results routing.
 
-**App version:** Footer label and `MILI_APP_VERSION` in `apiToMongo.js` (keep in sync) — currently **5.4**.
+**App version:** Footer label and `MILI_APP_VERSION` in `apiToMongo.js` (keep in sync) — currently **5.6**.
 
 ---
 
@@ -218,8 +218,8 @@ Loaded **before** root `recording.js`, which exposes the unified API the game us
 | `flow/` | Timers, mic intro, start screens, load question / index |
 | `scoring/` | Comprehension tap scoring and advance rules |
 | `ui/` | Pause/AFK, overlays, question layout, session-complete screen |
-| `expression/` | `expressionSegmentUploadQueue.js` — per-question upload state, cancel/wait helpers |
-| `finish/` | End session, upload pipeline, expression AI polling, incremental queue drain + score reconcile |
+| `expression/` | `expressionSegmentUploadQueue.js` — Q-keyed blobs, 3× retry, cancel/wait/finish burst helpers |
+| `finish/` | End session, upload pipeline, expression AI polling, incremental drain + finish retry burst |
 
 ---
 
@@ -260,13 +260,17 @@ At login, the parent chooses expression recording mode:
 | `record_session/*` | Implementation (capture, timestamps, encode) |
 | `recording.js` | Facade → **`SessionRecorder`** global |
 | `js/record_session/expressionSegmentRecorder.js` | Incremental segment capture (one segment per expression question) |
-| `js/test/expression/expressionSegmentUploadQueue.js` | Incremental async queue: encode + upload + register segment |
+| `js/test/expression/expressionSegmentUploadQueue.js` | Incremental async queue: encode + upload + register segment; Q-keyed blob retention; up to 3 retries per question |
 | `test.js` + modules | Starts mode-specific recording flow, marks timestamps in legacy, and enqueues segment uploads in incremental |
 
 On finish, `testSessionFinish.js` branches by mode:
 
 - **`legacy`**: waits for session MP3, uploads via SAS, then calls `updateUserTests` with scores + timestamp text.
-- **`incremental`**: `testScoring.js` enqueues the last segment before advance/finish; drains pending uploads (60s on finish), freezes the 20s expression countdown during drain, skips full-session blob upload, calls `updateUserTests` for metadata-only finalize, then `releaseIncrementalCaptureResources()` on success. Score counters are reconciled from deduped `questionResults` at finish.
+- **`incremental`**: `testScoring.js` enqueues the last segment before advance/finish; at finish runs a 30s retry burst for failed uploads (only), then drains pending uploads (60s), freezes the 20s expression countdown during drain, always calls `updateUserTests` for metadata-only finalize (no legacy full-audio fallback when zero segments succeed), then `releaseIncrementalCaptureResources()` on success. Score counters are reconciled from deduped `questionResults` at finish. Summary / expression AI polling waits for full `done` with no 30s UI cap.
+
+### Incremental upload retry (iOS / flaky network)
+
+When prepare, blob PUT, or segment register fails (common during phone calls on iOS), the client retries up to **3 times** per question with 1s/2s backoff. Blobs stay in `pendingUploads[questionNumber]` until register succeeds. At finish, eligible failed uploads get a **30s retry burst** before the **60s** main queue drain. Exhausted uploads are recorded in `clientInfo.segmentUpload` at finalize; the server inserts `processing_failed` fallback rows for missing segments. Parent-visible AI text is unchanged for those rows.
 
 ### Incremental segment interrupt (mic / call)
 
@@ -279,7 +283,7 @@ Only when `expressionAudioMode === "incremental"` and on an expression question:
 | After interrupt | 20s countdown frozen; navbar and question UI hidden; re-record gated on live `getUserMedia`; mandatory re-record until segment is registered on server (Continue only when upload `completed`) |
 | Restart | `restartCurrentIncrementalExpressionQuestion` — cancel pending queue jobs for that question; blocked after server register; waits on `in_flight` upload |
 
-Queue helpers: `getQuestionUploadState`, `cancelPendingForQuestion`, `waitForQuestionIdle`. Segment blobs are bound to their originating question number (no cross-question reuse).
+Queue helpers: `getQuestionUploadState`, `cancelPendingForQuestion`, `waitForQuestionIdle`, `runFinishRetryBurst`, `getSegmentUploadClientInfo`. Segment blobs are bound to their originating question number (no cross-question reuse).
 
 ### Token results page (`?t=` / `?results=`)
 
@@ -314,7 +318,7 @@ Expression scoring runs on the server in both modes:
 - **`legacy`**: mainly after finish, using slices from the uploaded session audio.
 - **`incremental`**: continuously during test from uploaded expression segments; finalize waits for all expression rows (server retries + fallbacks), then impression; summary polls until `done` with `processed >= total`.
 
-**Changelog (28 May 2026):** [`../changes/CHANGES_2026-05-28_28.md`](../changes/CHANGES_2026-05-28_28.md) — full numbered list (login mode, segment APIs, interrupt recovery, results routing fix, version 5.4).
+**Changelog (30 May 2026):** [`../changes/CHANGES_2026-05-30_30.md`](../changes/CHANGES_2026-05-30_30.md) — segment upload retry, finish recovery, version 5.6. Prior: [`../changes/CHANGES_2026-05-28_28.md`](../changes/CHANGES_2026-05-28_28.md).
 
 ---
 

--- a/frontend_demo/docs/STRUCTURE.md
+++ b/frontend_demo/docs/STRUCTURE.md
@@ -27,7 +27,7 @@ frontend_demo/
       scoring/               # Comprehension scoring
       expression/            # expressionSegmentUploadQueue.js (incremental)
       ui/                    # Pause/AFK, overlays (incl. incremental interrupt), summary
-      finish/                # Session complete, expression AI poll, incremental drain
+      finish/                # Session complete, expression AI poll, incremental drain + finish retry burst
 ```
 
 ## Global namespaces

--- a/frontend_demo/docs/TEST_MODULE_MAP.md
+++ b/frontend_demo/docs/TEST_MODULE_MAP.md
@@ -79,7 +79,7 @@ Run after each phase:
 7. Upload retry after failure (optional).
 8. Dev Ctrl+Q jump (if dev code touched).
 9. Early Finish dialog (incomplete test): opens via `pauseTest()` (same as navbar pause); recording + expression 20s freeze; no `markQuestionEnd` while dialog open (`MiliTestFinishDialog`); navbar pause hidden; Stay calls `resumeTest()`; finish anyway uses `completeSession` only (no resume).
-10. **Incremental** — login mode `incremental`; segment uploads during test; last question enqueue-before-finish; countdown freezes during upload drain; finish metadata-only + mic release; summary waits for `expressionAiStatus` `done` with full progress.
+10. **Incremental** — login mode `incremental`; segment uploads during test (3 client retries, Q-keyed blobs); last question enqueue-before-finish; finish retry burst 30s + queue drain 60s; countdown freezes during upload drain; finish metadata-only + mic release; summary waits for `expressionAiStatus` `done` with full progress (no 30s UI cap).
 11. **Incremental interrupt** — revoke mic during answer window → full-screen interrupt + re-record; mic off during prompt → interrupt at timer arm (no modal during prompt); restart blocked after segment registered; Android call with live track → no false interrupt when applicable.
 12. **Results routing** — open `?t=` valid token → results; open app without token after prior results visit → welcome/home (not “התוצאות לא נמצאו”); mid-test resume keys intact when alternating SMS link and home.
 

--- a/frontend_demo/js/api/apiToMongo.js
+++ b/frontend_demo/js/api/apiToMongo.js
@@ -139,13 +139,13 @@ async function createUser(userId, userName, parentPhone) {
 var PENDING_TEST_ID_KEY = "seeandsayPendingTestId";
 var PENDING_BLOB_UPLOADED_KEY = "seeandsayPendingBlobUploaded";
 /** Keep in sync with `app-version-label` in js/app/app.js */
-var MILI_APP_VERSION = "5.5";
+var MILI_APP_VERSION = "5.6";
 
 /**
  * Debug metadata sent with each finished test (device, browser, upload state).
  * @param {string|number} demoUserId - UI/local idDigits passed to API layer
  * @param {string} [testId] - pending test id at finish
- * @param {{ blobUploadOk?: boolean }} [opts]
+ * @param {{ blobUploadOk?: boolean, segmentUpload?: object }} [opts]
  */
 function collectClientInfo(demoUserId, testId, opts) {
   opts = opts || {};
@@ -219,6 +219,10 @@ function collectClientInfo(demoUserId, testId, opts) {
     }
   } catch (collectErr) {
     info.collectError = collectErr && collectErr.message ? collectErr.message : String(collectErr);
+  }
+
+  if (opts.segmentUpload && typeof opts.segmentUpload === "object") {
+    info.segmentUpload = opts.segmentUpload;
   }
 
   return info;
@@ -438,10 +442,13 @@ async function updateUserTests(
   timestampText,
   childGender,
   audioBlobPath,
-  testId
+  testId,
+  finalizeOpts
 ) {
   const url = getApiBaseUrl() + "/api/addTestToUser";
   var apiUserId = resolveBackendUserId(userId);
+  var collectOpts =
+    finalizeOpts && typeof finalizeOpts === "object" && !Array.isArray(finalizeOpts) ? finalizeOpts : {};
 
   try {
     console.log("📤 Uploading test data to MongoDB...");
@@ -459,7 +466,7 @@ async function updateUserTests(
     }
     console.log("   Timestamps:", timestampText ? "Present" : "None");
 
-    var clientInfo = collectClientInfo(userId, testId);
+    var clientInfo = collectClientInfo(userId, testId, collectOpts);
     console.log(
       "   clientInfo:",
       clientInfo.appVersion,

--- a/frontend_demo/js/app/app.js
+++ b/frontend_demo/js/app/app.js
@@ -368,7 +368,7 @@ function App() {
     React.createElement(
       "div",
       { className: "app-version-label", "aria-hidden": "true" },
-      "version 5.5"
+      "version 5.6"
     ),
     /* Reset button moved to test navbar */
     showResetConfirm

--- a/frontend_demo/js/test/expression/expressionSegmentUploadQueue.js
+++ b/frontend_demo/js/test/expression/expressionSegmentUploadQueue.js
@@ -1,7 +1,12 @@
 /**
  * Non-blocking sequential upload queue for expression segments.
+ * Retains blobs per question until register succeeds; retries failed uploads.
  */
 (function () {
+  var MAX_ATTEMPTS = 3;
+  var RETRY_DELAYS_MS = [1000, 2000];
+  var FINISH_RETRY_BURST_MS = 30000;
+
   function convertBlobToMp3(blob) {
     if (!blob) return Promise.resolve(null);
     return new Promise(function (resolve) {
@@ -39,14 +44,37 @@
     var queue = [];
     var running = false;
     var completed = 0;
-    var failed = 0;
+    var exhaustedCount = 0;
     var idleWaiters = [];
     var currentJob = null;
     var completedQuestions = {};
     var failedQuestions = {};
+    var pendingUploads = {};
+    var retryTimerCount = 0;
+    var trackedQuestionKeys = {};
 
     function qKey(questionNumber) {
       return String(questionNumber || "").trim();
+    }
+
+    function trackQuestionKey(key) {
+      if (key) trackedQuestionKeys[key] = true;
+    }
+
+    function isQuestionInQueue(key) {
+      for (var i = 0; i < queue.length; i++) {
+        if (qKey(queue[i].questionNumber) === key) return true;
+      }
+      return false;
+    }
+
+    function pendingCount() {
+      var retrying = 0;
+      Object.keys(pendingUploads).forEach(function (key) {
+        var entry = pendingUploads[key];
+        if (entry && entry.status === "retrying") retrying += 1;
+      });
+      return queue.length + (running ? 1 : 0) + retryTimerCount + retrying;
     }
 
     function flushIdleWaiters() {
@@ -73,11 +101,27 @@
       if (!key) return "none";
       if (completedQuestions[key]) return "completed";
       if (isUploadInFlight(key)) return "in_flight";
-      for (var i = 0; i < queue.length; i++) {
-        if (qKey(queue[i].questionNumber) === key) return "pending";
-      }
-      if (failedQuestions[key]) return "failed";
+      var entry = pendingUploads[key];
+      if (entry && entry.status === "retrying") return "retrying";
+      if (isQuestionInQueue(key)) return "pending";
+      if (entry && entry.status === "exhausted") return "exhausted";
+      if (failedQuestions[key]) return "exhausted";
+      if (entry && entry.segmentBlob) return "pending";
       return "none";
+    }
+
+    function buildByQuestionMap() {
+      var byQuestion = {};
+      Object.keys(trackedQuestionKeys).forEach(function (key) {
+        byQuestion[key] = getQuestionUploadState(key);
+      });
+      Object.keys(pendingUploads).forEach(function (key) {
+        if (!byQuestion[key]) byQuestion[key] = getQuestionUploadState(key);
+      });
+      Object.keys(completedQuestions).forEach(function (key) {
+        byQuestion[key] = "completed";
+      });
+      return byQuestion;
     }
 
     function cancelPendingForQuestion(questionNumber) {
@@ -87,7 +131,56 @@
       queue = queue.filter(function (job) {
         return qKey(job.questionNumber) !== key;
       });
+      delete pendingUploads[key];
+      delete failedQuestions[key];
+      delete completedQuestions[key];
+      delete trackedQuestionKeys[key];
       return before - queue.length;
+    }
+
+    function pushQueueEntry(questionNumber) {
+      var key = qKey(questionNumber);
+      if (!key || isQuestionInQueue(key)) return;
+      queue.push({ questionNumber: key });
+      setTimeout(runNext, 0);
+    }
+
+    function scheduleRetry(questionNumber) {
+      var key = qKey(questionNumber);
+      var entry = pendingUploads[key];
+      if (!entry || entry.attemptCount >= MAX_ATTEMPTS) return;
+      if (isQuestionInQueue(key) || isUploadInFlight(key)) return;
+      var delayIdx = Math.min(Math.max(entry.attemptCount - 1, 0), RETRY_DELAYS_MS.length - 1);
+      var delayMs = RETRY_DELAYS_MS[delayIdx] || RETRY_DELAYS_MS[RETRY_DELAYS_MS.length - 1];
+      entry.status = "retrying";
+      retryTimerCount += 1;
+      setTimeout(function () {
+        retryTimerCount = Math.max(0, retryTimerCount - 1);
+        var current = pendingUploads[key];
+        if (!current || completedQuestions[key]) {
+          flushIdleWaiters();
+          return;
+        }
+        if (current.attemptCount >= MAX_ATTEMPTS) {
+          flushIdleWaiters();
+          return;
+        }
+        current.status = "pending";
+        pushQueueEntry(key);
+        flushIdleWaiters();
+      }, delayMs);
+    }
+
+    function markExhausted(key, err) {
+      var entry = pendingUploads[key];
+      if (entry && entry.status === "exhausted") return;
+      if (entry) {
+        entry.status = "exhausted";
+        entry.lastError = err && err.message ? err.message : String(err || "upload failed");
+      }
+      failedQuestions[key] = true;
+      exhaustedCount += 1;
+      console.error("[segmentQueue] upload exhausted q" + key, err);
     }
 
     async function runNext() {
@@ -95,30 +188,51 @@
       running = true;
       while (queue.length) {
         var job = queue.shift();
-        currentJob = job;
+        var key = qKey(job && job.questionNumber);
+        if (!key) {
+          currentJob = null;
+          continue;
+        }
+        var entry = pendingUploads[key];
+        if (!entry || !entry.segmentBlob) {
+          currentJob = null;
+          continue;
+        }
+        currentJob = { questionNumber: key };
+        entry.status = "in_flight";
         try {
-          var mp3Blob = await convertBlobToMp3(job.segmentBlob);
-          var prep = await deps.prepareSegmentUpload(job.userId, job.testId, job.questionNumber);
+          var mp3Blob = await convertBlobToMp3(entry.segmentBlob);
+          var prep = await deps.prepareSegmentUpload(entry.userId, entry.testId, key);
           if (!prep || prep.success === false) throw new Error((prep && prep.error) || "prepare failed");
           var put = await deps.putSessionAudioToBlob(prep.uploadUrl, mp3Blob);
           if (!put || put.success === false) throw new Error((put && put.error) || "put failed");
-          await deps.registerExpressionSegment(job.userId, {
-            testId: job.testId,
-            questionNumber: String(job.questionNumber),
+          await deps.registerExpressionSegment(entry.userId, {
+            testId: entry.testId,
+            questionNumber: key,
             blobPath: prep.blobPath,
-            headlightResult: job.headlightResult || null,
-            childGender: job.childGender || null,
-            ageYears: job.ageYears,
-            ageMonths: job.ageMonths,
+            headlightResult: entry.headlightResult || null,
+            childGender: entry.childGender || null,
+            ageYears: entry.ageYears,
+            ageMonths: entry.ageMonths,
           });
           completed += 1;
-          completedQuestions[qKey(job.questionNumber)] = true;
-          delete failedQuestions[qKey(job.questionNumber)];
-          console.log("[segmentQueue] uploaded q" + job.questionNumber + " (completed=" + completed + ")");
+          completedQuestions[key] = true;
+          delete failedQuestions[key];
+          delete pendingUploads[key];
+          console.log("[segmentQueue] uploaded q" + key + " (completed=" + completed + ")");
         } catch (err) {
-          failed += 1;
-          failedQuestions[qKey(job.questionNumber)] = true;
-          console.error("[segmentQueue] upload failed", err);
+          entry.attemptCount = (entry.attemptCount || 0) + 1;
+          entry.lastError = err && err.message ? err.message : String(err || "upload failed");
+          if (entry.attemptCount < MAX_ATTEMPTS) {
+            entry.status = "pending";
+            console.warn(
+              "[segmentQueue] upload failed q" + key + " attempt " + entry.attemptCount + "/" + MAX_ATTEMPTS,
+              err
+            );
+            scheduleRetry(key);
+          } else {
+            markExhausted(key, err);
+          }
         }
         currentJob = null;
       }
@@ -126,24 +240,49 @@
       flushIdleWaiters();
     }
 
-    function enqueue(job) {
+    function storePendingFromJob(job) {
       var key = qKey(job && job.questionNumber);
-      if (key) {
-        delete failedQuestions[key];
-      }
-      queue.push(job);
-      setTimeout(runNext, 0);
+      if (!key || !job || !job.segmentBlob) return null;
+      trackQuestionKey(key);
+      pendingUploads[key] = {
+        segmentBlob: job.segmentBlob,
+        userId: job.userId,
+        testId: job.testId,
+        headlightResult: job.headlightResult,
+        childGender: job.childGender,
+        ageYears: job.ageYears,
+        ageMonths: job.ageMonths,
+        attemptCount: 0,
+        lastError: null,
+        status: "pending",
+      };
+      delete failedQuestions[key];
+      return key;
     }
 
-    function pendingCount() {
-      return queue.length + (running ? 1 : 0);
+    function enqueue(job) {
+      var key = storePendingFromJob(job);
+      if (!key) return;
+      pushQueueEntry(key);
     }
 
     function stats() {
       return {
         pending: pendingCount(),
         completed: completed,
-        failed: failed,
+        failed: exhaustedCount,
+        exhausted: exhaustedCount,
+        byQuestion: buildByQuestionMap(),
+      };
+    }
+
+    function getSegmentUploadClientInfo() {
+      var s = stats();
+      return {
+        completed: s.completed,
+        exhausted: s.exhausted,
+        pending: s.pending,
+        byQuestion: s.byQuestion,
       };
     }
 
@@ -169,13 +308,29 @@
       });
     }
 
+    function runFinishRetryBurst(timeoutMs) {
+      var burstMs =
+        typeof timeoutMs === "number" && timeoutMs > 0 ? timeoutMs : FINISH_RETRY_BURST_MS;
+      Object.keys(pendingUploads).forEach(function (key) {
+        if (completedQuestions[key]) return;
+        var entry = pendingUploads[key];
+        if (!entry || !entry.segmentBlob) return;
+        if (entry.attemptCount >= MAX_ATTEMPTS) return;
+        if (entry.status === "in_flight" || entry.status === "retrying") return;
+        entry.status = "pending";
+        delete failedQuestions[key];
+        pushQueueEntry(key);
+      });
+      return waitForIdle(burstMs);
+    }
+
     function waitForQuestionIdle(questionNumber, timeoutMs) {
       var waitMs = typeof timeoutMs === "number" && timeoutMs > 0 ? timeoutMs : 25000;
       return new Promise(function (resolve) {
         var start = Date.now();
         function tick() {
           var state = getQuestionUploadState(questionNumber);
-          if (state !== "pending" && state !== "in_flight") {
+          if (state !== "pending" && state !== "in_flight" && state !== "retrying") {
             resolve(state);
             return;
           }
@@ -193,7 +348,9 @@
       enqueue: enqueue,
       pendingCount: pendingCount,
       stats: stats,
+      getSegmentUploadClientInfo: getSegmentUploadClientInfo,
       waitForIdle: waitForIdle,
+      runFinishRetryBurst: runFinishRetryBurst,
       cancelPendingForQuestion: cancelPendingForQuestion,
       isUploadInFlight: isUploadInFlight,
       hasCompletedUpload: hasCompletedUpload,

--- a/frontend_demo/js/test/finish/testSessionFinish.js
+++ b/frontend_demo/js/test/finish/testSessionFinish.js
@@ -159,6 +159,13 @@
           if (typeof pipelineCtx.beginExpressionEvalFreezeForIncrementalUpload === "function") {
             pipelineCtx.beginExpressionEvalFreezeForIncrementalUpload();
           }
+          if (typeof pipelineCtx.runExpressionSegmentFinishRetryBurst === "function") {
+            try {
+              pipelineCtx.setTestUploadState("saving_metadata");
+              seedLocalExpressionUploadPhase("scoring_questions");
+              await pipelineCtx.runExpressionSegmentFinishRetryBurst(30000);
+            } catch (burstErr) {}
+          }
           if (typeof pipelineCtx.waitForExpressionSegmentQueueIdle === "function") {
             try {
               pipelineCtx.setTestUploadState("saving_metadata");
@@ -166,22 +173,19 @@
               await pipelineCtx.waitForExpressionSegmentQueueIdle(60000);
             } catch (idleErr) {}
           }
-          var segStats =
-            typeof pipelineCtx.getExpressionSegmentUploadStats === "function"
-              ? pipelineCtx.getExpressionSegmentUploadStats()
-              : { pending: 0, completed: 0, failed: 0 };
-          var hasUploadedSegments = (segStats && segStats.completed > 0);
-          if (!hasUploadedSegments) {
-            console.warn(
-              "[incremental] no uploaded segments before finish; falling back to legacy full-audio upload"
-            );
-          } else {
           pipelineCtx.setTestUploadState("saving_metadata");
           pipelineCtx.expressionPhaseRecordingStartedRef.current = false;
           if (typeof pipelineCtx.releaseIncrementalCaptureResources === "function") {
             pipelineCtx.releaseIncrementalCaptureResources();
           }
           pipelineCtx.setSessionCompleted(true);
+          var incrementalFinalizeOpts = null;
+          if (typeof pipelineCtx.getExpressionSegmentUploadClientInfo === "function") {
+            var segmentUploadInfo = pipelineCtx.getExpressionSegmentUploadClientInfo();
+            if (segmentUploadInfo) {
+              incrementalFinalizeOpts = { segmentUpload: segmentUploadInfo };
+            }
+          }
           var incrementalResult = await pipelineCtx.updateUserTests(
             pipelineCtx.idDigits,
             pipelineCtx.ageYears,
@@ -194,11 +198,11 @@
             null,
             pipelineCtx.childGender,
             null,
-            pipelineCtx.ensurePendingTestId()
+            pipelineCtx.ensurePendingTestId(),
+            incrementalFinalizeOpts
           );
           handleUploadResult(incrementalResult);
           return;
-          }
         }
         pipelineCtx.setTestUploadState("preparing_recording");
 

--- a/frontend_demo/js/test/test.js
+++ b/frontend_demo/js/test/test.js
@@ -436,6 +436,28 @@ function Test({ allQuestions, lang, t, onHome, onReset, setLang, onTestPhase }) 
     expressionSegmentRecorderRef.current.clearLastBlob();
   }
 
+  function getExpressionSegmentUploadStatsFromQueue() {
+    return expressionSegmentQueueRef.current && expressionSegmentQueueRef.current.stats
+      ? expressionSegmentQueueRef.current.stats()
+      : { pending: 0, completed: 0, failed: 0, exhausted: 0, byQuestion: {} };
+  }
+
+  function getExpressionSegmentUploadClientInfoFromQueue() {
+    return expressionSegmentQueueRef.current && expressionSegmentQueueRef.current.getSegmentUploadClientInfo
+      ? expressionSegmentQueueRef.current.getSegmentUploadClientInfo()
+      : null;
+  }
+
+  async function waitForExpressionSegmentQueueIdleFn(timeoutMs) {
+    if (!expressionSegmentQueueRef.current || !expressionSegmentQueueRef.current.waitForIdle) return;
+    await expressionSegmentQueueRef.current.waitForIdle(timeoutMs);
+  }
+
+  async function runExpressionSegmentFinishRetryBurstFn(timeoutMs) {
+    if (!expressionSegmentQueueRef.current || !expressionSegmentQueueRef.current.runFinishRetryBurst) return;
+    await expressionSegmentQueueRef.current.runFinishRetryBurst(timeoutMs);
+  }
+
   function releaseIncrementalCaptureResources() {
     if (getExpressionAudioMode() !== "incremental") return;
     if (expressionSegmentRecorderRef.current && expressionSegmentRecorderRef.current.cleanup) {
@@ -3238,15 +3260,10 @@ function Test({ allQuestions, lang, t, onHome, onReset, setLang, onTestPhase }) 
         ? expressionSegmentQueueRef.current.pendingCount()
         : 0;
     },
-    getExpressionSegmentUploadStats: function () {
-      return expressionSegmentQueueRef.current && expressionSegmentQueueRef.current.stats
-        ? expressionSegmentQueueRef.current.stats()
-        : { pending: 0, completed: 0, failed: 0 };
-    },
-    waitForExpressionSegmentQueueIdle: async function (timeoutMs) {
-      if (!expressionSegmentQueueRef.current || !expressionSegmentQueueRef.current.waitForIdle) return;
-      await expressionSegmentQueueRef.current.waitForIdle(timeoutMs);
-    },
+    getExpressionSegmentUploadStats: getExpressionSegmentUploadStatsFromQueue,
+    getExpressionSegmentUploadClientInfo: getExpressionSegmentUploadClientInfoFromQueue,
+    waitForExpressionSegmentQueueIdle: waitForExpressionSegmentQueueIdleFn,
+    runExpressionSegmentFinishRetryBurst: runExpressionSegmentFinishRetryBurstFn,
     reconcileSessionScoreCounters: reconcileSessionScoreCountersFromResults,
     beginExpressionEvalFreezeForIncrementalUpload: beginExpressionEvalFreezeForIncrementalUpload,
     releaseIncrementalCaptureResources: releaseIncrementalCaptureResources,
@@ -3297,10 +3314,8 @@ function Test({ allQuestions, lang, t, onHome, onReset, setLang, onTestPhase }) 
     requestCompleteSessionOrConfirm: requestCompleteSessionOrConfirm,
     enqueueExpressionSegmentUpload: enqueueExpressionSegmentUpload,
     getExpressionAudioMode: getExpressionAudioMode,
-    waitForExpressionSegmentQueueIdle: async function (timeoutMs) {
-      if (!expressionSegmentQueueRef.current || !expressionSegmentQueueRef.current.waitForIdle) return;
-      await expressionSegmentQueueRef.current.waitForIdle(timeoutMs);
-    },
+    waitForExpressionSegmentQueueIdle: waitForExpressionSegmentQueueIdleFn,
+    runExpressionSegmentFinishRetryBurst: runExpressionSegmentFinishRetryBurstFn,
     beginExpressionEvalFreezeForIncrementalUpload: beginExpressionEvalFreezeForIncrementalUpload,
     openIncompleteSummaryConfirm: openIncompleteSummaryConfirm,
     tryGateExpressionMicCheckBeforeNavigatingTo: tryGateExpressionMicCheckBeforeNavigatingTo,


### PR DESCRIPTION
## PR title

iOS incremental segment upload network retry and finish recovery

## Summary (2-3 bullets)

- Hardened incremental expression segment uploads against iOS call and flaky-network failures with Q-keyed blob retention (`pendingUploads`) and up to three client retries per question (1s/2s backoff).
- Finish always proceeds via incremental metadata finalize after a 60s queue drain plus a 30s finish retry burst for failed uploads only; summary and AI polling remain uncapped until full `done`.
- Bumped app to 5.6; added `clientInfo.segmentUpload` debug stats; synced READMEs across root, frontend, and backend docs.

## numbered main changes

1. Added `pendingUploads[questionNumber]` map in `expressionSegmentUploadQueue.js` so segment blobs are retained until `registerExpressionSegment` succeeds (Option B).
2. Added per-question upload retry (max 3 attempts, 1s/2s backoff) on prepare, PUT, and register failures; `exhausted` state when attempts are used up.
3. Extended queue API with `getSegmentUploadClientInfo()`, `runFinishRetryBurst(30000)`, enriched `stats()` / `getQuestionUploadState`, and `cancelPendingForQuestion` clearing the pending map.
4. Updated `testSessionFinish.js`: finish retry burst (30s, failed uploads only), keep 60s main queue drain, remove `completed > 0` legacy full-audio fallback, always incremental metadata finalize.
5. Threaded `clientInfo.segmentUpload` at finalize via `updateUserTests` → `collectClientInfo` in `apiToMongo.js`.
6. Wired queue helpers in `test.js` (`getExpressionSegmentUploadClientInfo`, `runExpressionSegmentFinishRetryBurst`).
7. Bumped app footer and `MILI_APP_VERSION` to **5.6** in `app.js` and `apiToMongo.js`.
8. Updated `README.md`, `frontend_demo/README.md`, `backend/docs/README.md`, `backend/docs/BACKEND_MODULE_MAP.md`, and `frontend_demo/docs/TEST_MODULE_MAP.md` for retry/finish behavior and May 30 changelog link.

## numbered notes

1. Re-test iPhone 15 + Chrome with incoming call during expression (e.g. Q33–39); compare `clientInfo.segmentUpload.byQuestion` vs Mongo `expressionSegments`.
2. Parent UI unchanged when upload exhausts retries: server `processing_failed` row with Hebrew observation from `_build_processing_failed_expression_row`.
3. The 30s cap applies only to the finish retry burst for failed uploads, not to expression AI polling or summary display (no partial impression after 30s).
4. Visibility-based upload retry intentionally not primary (iOS Chrome often stays `visible` during calls).